### PR TITLE
expose whether a certain controller is active in the state message

### DIFF
--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -12,6 +12,21 @@ namespace auv_control{
         bool linear[3];
         bool angular[3];
     };
+
+    struct PIDState : public motor_controller::PIDState
+    {
+        bool active;
+
+        PIDState()
+            : motor_controller::PIDState(), active(false) {}
+        PIDState(motor_controller::PIDState const& state, bool active)
+            : motor_controller::PIDState(state), active(active) {}
+    };
+
+    struct LinearAngular6DPIDState{
+        PIDState linear[3];
+        PIDState angular[3];
+    };
 }    
 
 namespace base{
@@ -101,11 +116,6 @@ namespace base{
         bool operator!=(const LinearAngular6DParallelPIDSettings& rhs) const{
             return !(*this == rhs);
         }
-    };
-
-    struct LinearAngular6DPIDState{
-        motor_controller::PIDState linear[3];
-        motor_controller::PIDState angular[3];
     };
 }
 #endif

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -100,7 +100,7 @@ task_context 'BasePIDController' do
     output_port 'cmd_out', 'base::LinearAngular6DCommand'
 
     # The states of the pid-controllers
-    output_port 'pid_state', 'base::LinearAngular6DPIDState'
+    output_port 'pid_state', '/auv_control/LinearAngular6DPIDState'
     
     error_states :WAIT_FOR_POSE_SAMPLE
     

--- a/tasks/BasePIDController.cpp
+++ b/tasks/BasePIDController.cpp
@@ -1,6 +1,7 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "BasePIDController.hpp"
+#include <auv_control/6dControl.hpp>
 
 using namespace auv_control;
 
@@ -95,7 +96,7 @@ bool BasePIDController::calcOutput()
     // We start by copying merged_command so that we can simply ignore the unset
     // values
     base::LinearAngular6DCommand output_command = merged_command;
-    base::LinearAngular6DPIDState pid_state;
+    LinearAngular6DPIDState pid_state;
     for (int i = 0; i < 3; ++i)
     {
         if (!base::isUnset(merged_command.linear(i)))
@@ -104,7 +105,11 @@ bool BasePIDController::calcOutput()
                 mLinearPIDs[i].update(currentLinear(i),
                                    merged_command.linear(i),
                                    merged_command.time.toSeconds());
-            pid_state.linear[i] = mLinearPIDs[i].getState();
+            pid_state.linear[i] = auv_control::PIDState(mLinearPIDs[i].getState(), true);
+        }
+        else
+        {
+            pid_state.linear[i].active = false;
         }
         if (!base::isUnset(merged_command.angular(i)))
         {
@@ -112,7 +117,11 @@ bool BasePIDController::calcOutput()
                 mAngularPIDs[i].update(currentAngular(i),
                                    merged_command.angular(i),
                                    merged_command.time.toSeconds());
-            pid_state.angular[i] = mAngularPIDs[i].getState();
+            pid_state.angular[i] = auv_control::PIDState(mAngularPIDs[i].getState(), true);
+        }
+        else
+        {
+            pid_state.angular[i].active = false;
         }
     }
 


### PR DESCRIPTION
This involves moving the LinearAngular6DPIDState type from base::
to auv_control::, but given that it was including
motor_controller::PIDState, I don't see why it was in base:: in the
first place.
