### PR TITLE
export the effort that AccelerationController expects to be actually applied on the system

### DIFF
--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -208,6 +208,9 @@ task_context "AccelerationController" do
     
     # Generated motor commands
     output_port "cmd_out", "base::commands::Joints"
+
+    # The expected generated effort (as opposed to the input effort)
+    output_port "expected_effort", "/base/LinearAngular6DCommand"
     
     exception_states :WRONG_SIZE_OF_CONTROLMODES, :WRONG_SIZE_OF_LIMITS, :WRONG_SIZE_OF_NAMES, :INVALID_NAME_IN_LIMITS 
 end

--- a/tasks/AccelerationController.hpp
+++ b/tasks/AccelerationController.hpp
@@ -15,6 +15,7 @@ namespace auv_control {
         base::MatrixXd thrusterMatrix;
         base::VectorXd inputVector;
         base::VectorXd cmdVector;
+        base::VectorXd expectedEffortVector;
         boost::shared_ptr<Eigen::JacobiSVD<Eigen::MatrixXd> > svd;
         base::commands::Joints jointCommand;
         std::vector<base::JointState::MODE> controlModes;


### PR DESCRIPTION
It is a great way to check for the end effect of saturation(s), and I
expect a good way to monitor the overall control scheme (e.g. verify
that the expected effort is meaningful w.r.t. what the system wants
to do or not)
