### PR TITLE
Implemented the weighted pseudo inverse.

### DIFF
--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -222,7 +222,7 @@ task_context "AccelerationController" do
     # The expected generated effort (as opposed to the input effort)
     output_port "expected_effort", "/base/LinearAngular6DCommand"
     
-    exception_states :WRONG_SIZE_OF_CONTROLMODES, :WRONG_SIZE_OF_LIMITS, :WRONG_SIZE_OF_NAMES, :WRONG_SIZE_THRUSTERS_WEIGHTS, :WRONG_VALUES_THRUSTERS_WEIGHTS, :INVALID_NAME_IN_LIMITS 
+    exception_states :WRONG_SIZE_OF_CONTROLMODES, :WRONG_SIZE_OF_LIMITS, :WRONG_SIZE_OF_NAMES, :INVALID_NAME_IN_LIMITS 
 end
 
 # Generates a single constant command in the configured domain

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -186,6 +186,13 @@ task_context "AccelerationController" do
     # The rows 0 to 2 of the matrix are the linear axis. The lines 3 to 5 of the
     # matrix are the angular axis.
     property "matrix", "base::MatrixXd"
+    
+    # Weights that indicate which thrusters should be prioritized in
+    # cases where multiple solutions are possible. The thrusters with lower
+    # weights will be prioritized. The property size should be equal to the number of
+    # thrusters and it must have only positive numbers. If there's no preference
+    # between the thrusters, just assign the same weight to all of them.
+    property "thrusters_weights", "base::VectorXd"
 
     # Names of the thrusters
     #
@@ -215,7 +222,7 @@ task_context "AccelerationController" do
     # The expected generated effort (as opposed to the input effort)
     output_port "expected_effort", "/base/LinearAngular6DCommand"
     
-    exception_states :WRONG_SIZE_OF_CONTROLMODES, :WRONG_SIZE_OF_LIMITS, :WRONG_SIZE_OF_NAMES, :INVALID_NAME_IN_LIMITS 
+    exception_states :WRONG_SIZE_OF_CONTROLMODES, :WRONG_SIZE_OF_LIMITS, :WRONG_SIZE_OF_NAMES, :WRONG_SIZE_THRUSTERS_WEIGHTS, :WRONG_VALUES_THRUSTERS_WEIGHTS, :INVALID_NAME_IN_LIMITS 
 end
 
 # Generates a single constant command in the configured domain

--- a/tasks/AccelerationController.cpp
+++ b/tasks/AccelerationController.cpp
@@ -34,37 +34,36 @@ bool AccelerationController::configureHook()
     base::MatrixXd weighingMatrix;
     base::VectorXd thrustersWeights = _thrusters_weights.get();
 
-
-	if(thrustersWeights.size() != numberOfThrusters)
+    if(thrustersWeights.size() != numberOfThrusters)
     {
-    	exception(WRONG_SIZE_THRUSTERS_WEIGHTS);
-    	return false;
+        exception(WRONG_SIZE_THRUSTERS_WEIGHTS);
+        return false;
     }
     else
     {
-    	for(int i = 0; i < thrustersWeights.size(); i++)
-    	{
-    		if(thrustersWeights[i] <= 0)
-    		{
-    			exception(WRONG_VALUES_THRUSTERS_WEIGHTS);
-    			return false;
-    		}
-    	}
-    	weighingMatrix = thrustersWeights.asDiagonal();
+        for(int i = 0; i < thrustersWeights.size(); i++)
+        {
+            if(thrustersWeights[i] <= 0)
+            {
+                exception(WRONG_VALUES_THRUSTERS_WEIGHTS);
+                return false;
+            }
+        }
+        weighingMatrix = thrustersWeights.asDiagonal();
     }
 
     if(_svd_calculation.get())
     {
-    	base::MatrixXd auxPseudoInverse;
+        base::MatrixXd auxPseudoInverse;
         svd.reset(new Eigen::JacobiSVD<Eigen::MatrixXd>(thrusterMatrix*weighingMatrix.inverse()*thrusterMatrix.transpose(),  Eigen::ComputeThinU | Eigen::ComputeThinV));
 
         // Pseudo-inverse of the svd matrix
         auxPseudoInverse = svd->solve(Eigen::MatrixXd::Identity(thrusterMatrix.rows(), thrusterMatrix.rows()));
 
         // Weighted pseudo-inverse used for optimal distribution of propulsion and control forces according to Fossen (1994, p. 98)
-    	weightedPseudoInverse = weighingMatrix.inverse()*thrusterMatrix.transpose()*auxPseudoInverse;
+        weightedPseudoInverse = weighingMatrix.inverse()*thrusterMatrix.transpose()*auxPseudoInverse;
 
-    	// SVD of the weighted pseudo-inverse to calculate the expectedEffortVector
+        // SVD of the weighted pseudo-inverse to calculate the expectedEffortVector
         svd.reset(new Eigen::JacobiSVD<Eigen::MatrixXd>(weightedPseudoInverse,  Eigen::ComputeThinU | Eigen::ComputeThinV));
     }
     else
@@ -74,7 +73,7 @@ bool AccelerationController::configureHook()
         exception(WRONG_SIZE_OF_NAMES);
         return false;
     }
-    
+
     if(_limits.get().size() != numberOfThrusters && !_limits.get().empty()){
         exception(WRONG_SIZE_OF_LIMITS);
         return false;
@@ -109,7 +108,7 @@ bool AccelerationController::configureHook()
     jointCommand = base::commands::Joints();
     jointCommand.names = names;
     jointCommand.elements.resize(numberOfThrusters);
-    
+
     return true;
 }
 
@@ -132,11 +131,11 @@ bool AccelerationController::calcOutput()
 
     if(_svd_calculation.get())
     {
-    	cmdVector = weightedPseudoInverse * inputVector;
+        cmdVector = weightedPseudoInverse * inputVector;
     }
     else
     {
-    	cmdVector = thrusterMatrix.transpose()*inputVector;
+        cmdVector = thrusterMatrix.transpose()*inputVector;
     }
 
     for (unsigned int i = 0; i < jointCommand.size(); ++i){

--- a/tasks/AccelerationController.cpp
+++ b/tasks/AccelerationController.cpp
@@ -35,19 +35,13 @@ bool AccelerationController::configureHook()
     base::VectorXd thrustersWeights = _thrusters_weights.get();
 
     if(thrustersWeights.size() != numberOfThrusters)
-    {
-        exception(WRONG_SIZE_THRUSTERS_WEIGHTS);
         return false;
-    }
     else
     {
         for(int i = 0; i < thrustersWeights.size(); i++)
         {
             if(thrustersWeights[i] <= 0)
-            {
-                exception(WRONG_VALUES_THRUSTERS_WEIGHTS);
                 return false;
-            }
         }
         weighingMatrix = thrustersWeights.asDiagonal();
     }

--- a/tasks/AccelerationController.hpp
+++ b/tasks/AccelerationController.hpp
@@ -13,6 +13,7 @@ namespace auv_control {
 	friend class AccelerationControllerBase;
     protected:
         base::MatrixXd thrusterMatrix;
+        base::MatrixXd weightedPseudoInverse;
         base::VectorXd inputVector;
         base::VectorXd cmdVector;
         base::VectorXd expectedEffortVector;


### PR DESCRIPTION
I've implemented this new method that is quite similar to the previous svd, but now we can set weights for the thrusters. In this method we can choose, for example, which thrusters should be used for a yaw rotation (surge or sway thrusters). 

I've created two exception states concerning the thrusters weights, one to avoid the number of weights to be different from the number of thrusters, and one to avoid negative or null weight values. The formula implemented on this commit is the following one:

![image](https://cloud.githubusercontent.com/assets/7912190/7367451/d51648b2-ed9f-11e4-9e00-6b2aa7363a2c.png)

More information about it can be seen in Fossen (1994, p. 98).

I've tested the code and when the user provides a proper vector of weights, the code is working good. But I'm having problems with the exception states. If an exception is detected (wrong size or wrong values) and then "false" is returned, the code breaks with the following message:

"`do_configure': failed to configure the '/AccelerationController' task of type auv_control::AccelerationController (Orocos::StateTransitionFailed)"

If I remove the line "return false", this problem doesn't happen but the system doesn't stay on exception state and it goes to CONTROLLING state. I'm suspicious this has something to do with the inheritance, but you guys might know it better.
