### PR TITLE
Make it possible to set the derivative mode for all PID controllers

### DIFF
--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -90,6 +90,9 @@ task_context 'BasePIDController' do
     # Use the Ideal (false) or Parallel PID-Settings 
     property "use_parallel_pid_settings", "bool", false
 
+    # Defines if the derivative will be applied to the error or to the output in the PID controller
+    property "apply_derivative_to_error", "bool", false
+
     # Under this Value the axis are not controled. Output is 0.
     property "variance_threshold", "double"
 

--- a/tasks/BasePIDController.cpp
+++ b/tasks/BasePIDController.cpp
@@ -58,6 +58,16 @@ bool BasePIDController::configureHook()
     if (! BasePIDControllerBase::configureHook())
         return false;
 
+    // set derivative mode
+    motor_controller::DerivativeMode derivative_mode = motor_controller::Output;
+    if(_apply_derivative_to_error)
+        derivative_mode = motor_controller::Error;
+    for (int i = 0; i < 3; ++i)
+    {
+        mLinearPIDs[i].setDerivativeMode(derivative_mode);
+        mAngularPIDs[i].setDerivativeMode(derivative_mode);
+    }
+
     use_parallel_pid_settings = _use_parallel_pid_settings;
     setPid_settings(_pid_settings.get());
     setParallel_pid_settings(_parallel_pid_settings.get());

--- a/tasks/BasePIDController.hpp
+++ b/tasks/BasePIDController.hpp
@@ -4,6 +4,7 @@
 #define AUV_CONTROL_BASEPIDCONTROLLER_TASK_HPP
 
 #include "auv_control/BasePIDControllerBase.hpp"
+#include <motor_controller/PID.hpp>
 
 namespace auv_control {
 


### PR DESCRIPTION
This flag could also become part of the pid settings. But since this configuration struct is used in many components, it seemed to be the better solution to have one separated property which is applied to all PID controllers in a PIDController task.
