### PR TITLE
Created a task to calculate the thruster generated force based on the thruster feedback

### DIFF
--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -318,11 +318,10 @@ task_context "OptimalHeadingController" do
     error_states :WAIT_FOR_ORIENTATION_SAMPLE
 end
 
-# Task that convert forces[N] to thruster's control signal.  
-# Receive as input AccelerationController.cmd_out and gives as output the control signal to the thruster's driver 
-# Configure the kind of control signal and thruster's properties
-task_context "ThrustersInput" do
+# Base task for ThrustersInput and ThrustersFeedback
+task_context "ThrustersBase" do
     needs_configuration
+    abstract
 
     # Convert thruster signal into forces, in positive direction or CW.
     # Should have a size equal to the number of thrusters
@@ -341,32 +340,45 @@ task_context "ThrustersInput" do
     # Thruster[N] = Coeff * voltage * |voltage|  
     property "thruster_voltage", "double", 0  
 
-    # Forces that each thruster should apply. Should contain data in cmd_in.effort
+    # The description about the ports are specified in ThrustersInput and
+    # ThrustersFeedback tasks
     input_port "cmd_in", "base::commands::Joints"
 
-    # Generated motor commands
     output_port "cmd_out", "base::commands::Joints"
 
     exception_states :UNSET_THRUSTER_INPUT, :UNEXPECTED_THRUSTER_INPUT 
                     
-    port_driven 'cmd_in'                   
+    port_driven 'cmd_in'
 end
 
-# Task that converts thruster's feedback from rpm to force.
+# Task that convert thruster forces to thruster's rotation.
+#
+# AccelerationController.cmd_out --> ThrustersInput --> Demultiplexer.cmd_in
+#
+task_context "ThrustersInput" do
+    needs_configuration
+    subclasses "ThrustersBase"
+
+    # cmd_in: forces that each thruster should apply. Should contain data in cmd_in.effort
+    # cmd_out: Generated motor commands
+end
+
+# Task that converts thruster's feedback from RPM or PWM to thruster forces.
+#
+# Multiplexer.joint_samples --> ThrustersFeedback --> ThrusterForce2BodyEffort.thruster_forces
+#
 task_context "ThrustersFeedback" do
     needs_configuration
-    subclasses "ThrustersInput"
+    subclasses "ThrustersBase"
 
-    # Feedback of the thrusters' rotation speed
-    input_port "joint_samples_in", "base::commands::Joints"
-
-    # Resulting forces for each one of the thrusters
-    output_port "forces_out", "base::commands::Joints"
-
-    port_driven 'joint_samples_in'
+    # cmd_in: thrusters rotation feedback
+    # cmd_out: thrusters forces
 end
 
-# Task that converts thruster's feedback from rpm to force.
+# Task that converts thruster's forces to body efforts.
+#
+# ThrustersFeedback.cmd_out --> ThrusterForce2BodyEffort --> Wherever body efforts are required
+#
 task_context "ThrusterForce2BodyEffort" do
     needs_configuration
 

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -352,6 +352,20 @@ task_context "ThrustersInput" do
     port_driven 'cmd_in'                   
 end
 
+# Task that converts thruster's feedback from rpm to force.
+task_context "ThrustersFeedback" do
+    needs_configuration
+    subclasses "ThrustersInput"
+
+    # Feedback of the thrusters' rotation speed
+    input_port "joint_samples_in", "base::commands::Joints"
+
+    # Resulting forces for each one of the thrusters
+    output_port "forces_out", "base::commands::Joints"
+
+    port_driven 'joint_samples_in'
+end
+
 # Task that works as switch betwen two commands
 task_context "CommandInjection" do
     subclasses "Base"

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -366,6 +366,27 @@ task_context "ThrustersFeedback" do
     port_driven 'joint_samples_in'
 end
 
+# Task that converts thruster's feedback from rpm to force.
+task_context "ThrusterForce2BodyEffort" do
+    needs_configuration
+
+    # Matrix with size of 6 * n. n means the count of thrusters that are used.
+    # The rows 0 to 2 of the matrix are the linear axis. The lines 3 to 5 of the
+    # matrix are the angular axis.
+    property "thruster_configuration_matrix", "base::MatrixXd"
+
+    # Thruster individual forces
+    input_port "thruster_forces", "base::commands::Joints"
+
+    # Body efforts once the thruster configuration matrix is applied to the
+    # thruster forces
+    output_port "body_efforts", "base::LinearAngular6DCommand"
+
+    exception_states :UNSET_THRUSTER_INPUT, :UNEXPECTED_THRUSTER_INPUT
+
+    port_driven 'thruster_forces'
+end
+
 # Task that works as switch betwen two commands
 task_context "CommandInjection" do
     subclasses "Base"

--- a/tasks/ThrusterForce2BodyEffort.cpp
+++ b/tasks/ThrusterForce2BodyEffort.cpp
@@ -54,17 +54,17 @@ void ThrusterForce2BodyEffort::updateHook()
         unsigned int numberOfThrusters = thrusterMatrix.cols();
         thrusterForcesVector = base::VectorXd::Zero(numberOfThrusters);
 
+        if(thrusterForces.elements.size() != numberOfThrusters)
+        {
+            LOG_ERROR("The input vector should have a size equal to %i, but actually it "
+                    "has size equal to %i. Check configuration. ",
+                    numberOfThrusters, thrusterForces.elements.size());
+            exception(UNEXPECTED_THRUSTER_INPUT);
+            return;
+        }
+
         for(int i = 0; i < numberOfThrusters; i++)
         {
-            if(thrusterForces.elements.size() != numberOfThrusters)
-            {
-                LOG_ERROR("The input vector should have a size equal to %i, but actually it "
-                        "has size equal to %i. Check configuration. ",
-                        numberOfThrusters, thrusterForces.elements.size());
-                exception(UNEXPECTED_THRUSTER_INPUT);
-                return;
-            }
-
             if(!thrusterForces.elements[i].hasEffort())
             {
                 std::string textThruster;

--- a/tasks/ThrusterForce2BodyEffort.cpp
+++ b/tasks/ThrusterForce2BodyEffort.cpp
@@ -63,7 +63,7 @@ void ThrusterForce2BodyEffort::updateHook()
             return;
         }
 
-        for(int i = 0; i < numberOfThrusters; i++)
+        for(uint i = 0; i < numberOfThrusters; i++)
         {
             if(!thrusterForces.elements[i].hasEffort())
             {

--- a/tasks/ThrusterForce2BodyEffort.cpp
+++ b/tasks/ThrusterForce2BodyEffort.cpp
@@ -46,7 +46,7 @@ void ThrusterForce2BodyEffort::updateHook()
 
     base::samples::Joints thrusterForces;
 
-    if(_thruster_forces.read(thrusterForces) == RTT::NewData)
+    while(_thruster_forces.read(thrusterForces) == RTT::NewData)
     {
         base::LinearAngular6DCommand bodyEffort;
         base::VectorXd thrusterForcesVector;

--- a/tasks/ThrusterForce2BodyEffort.cpp
+++ b/tasks/ThrusterForce2BodyEffort.cpp
@@ -1,0 +1,111 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ThrusterForce2BodyEffort.hpp"
+#include "base/Logging.hpp"
+
+using namespace auv_control;
+
+ThrusterForce2BodyEffort::ThrusterForce2BodyEffort(std::string const& name)
+    : ThrusterForce2BodyEffortBase(name)
+{
+}
+
+ThrusterForce2BodyEffort::ThrusterForce2BodyEffort(std::string const& name, RTT::ExecutionEngine* engine)
+    : ThrusterForce2BodyEffortBase(name, engine)
+{
+}
+
+ThrusterForce2BodyEffort::~ThrusterForce2BodyEffort()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ThrusterForce2BodyEffort.hpp for more detailed
+// documentation about them.
+
+bool ThrusterForce2BodyEffort::configureHook()
+{
+    if (! ThrusterForce2BodyEffortBase::configureHook())
+        return false;
+
+    thrusterMatrix = _thruster_configuration_matrix.get();
+
+    return true;
+}
+bool ThrusterForce2BodyEffort::startHook()
+{
+    if (! ThrusterForce2BodyEffortBase::startHook())
+        return false;
+    return true;
+}
+void ThrusterForce2BodyEffort::updateHook()
+{
+    ThrusterForce2BodyEffortBase::updateHook();
+
+    base::samples::Joints thrusterForces;
+
+    if(_thruster_forces.read(thrusterForces) == RTT::NewData)
+    {
+        base::LinearAngular6DCommand bodyEffort;
+        base::VectorXd thrusterForcesVector;
+        base::Vector6d bodyEffortVector;
+        unsigned int numberOfThrusters = thrusterMatrix.cols();
+        thrusterForcesVector = base::VectorXd::Zero(numberOfThrusters);
+
+        for(int i = 0; i < numberOfThrusters; i++)
+        {
+            if(thrusterForces.elements.size() != numberOfThrusters)
+            {
+                LOG_ERROR("The input vector should have a size equal to %i, but actually it "
+                        "has size equal to %i. Check configuration. ",
+                        numberOfThrusters, thrusterForces.elements.size());
+                exception(UNEXPECTED_THRUSTER_INPUT);
+                return;
+            }
+
+            if(!thrusterForces.elements[i].hasEffort())
+            {
+                std::cout << "teste 4" << std::endl;
+                std::string textThruster;
+
+                // Check whether names were specified for the thrusters
+                if(thrusterForces.names.size() == numberOfThrusters)
+                    textThruster = thrusterForces.names[i];
+                else
+                {
+                    std::stringstream number;
+                    number << i;
+                    textThruster = number.str();
+                }
+                LOG_ERROR("The field effort of the thruster %s was not set.",
+                        textThruster.c_str());
+                exception(UNSET_THRUSTER_INPUT);
+                return;
+            }
+
+            thrusterForcesVector[i] = thrusterForces.elements[i].effort;
+        }
+
+        bodyEffortVector = thrusterMatrix * thrusterForcesVector;
+
+        bodyEffort.linear = bodyEffortVector.head(3);
+        bodyEffort.angular = bodyEffortVector.tail(3);
+        bodyEffort.time = thrusterForces.time;
+
+        _body_efforts.write(bodyEffort);
+    }
+}
+void ThrusterForce2BodyEffort::errorHook()
+{
+    ThrusterForce2BodyEffortBase::errorHook();
+}
+void ThrusterForce2BodyEffort::stopHook()
+{
+    ThrusterForce2BodyEffortBase::stopHook();
+}
+void ThrusterForce2BodyEffort::cleanupHook()
+{
+    ThrusterForce2BodyEffortBase::cleanupHook();
+}

--- a/tasks/ThrusterForce2BodyEffort.cpp
+++ b/tasks/ThrusterForce2BodyEffort.cpp
@@ -67,7 +67,6 @@ void ThrusterForce2BodyEffort::updateHook()
 
             if(!thrusterForces.elements[i].hasEffort())
             {
-                std::cout << "teste 4" << std::endl;
                 std::string textThruster;
 
                 // Check whether names were specified for the thrusters

--- a/tasks/ThrusterForce2BodyEffort.hpp
+++ b/tasks/ThrusterForce2BodyEffort.hpp
@@ -1,0 +1,110 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef AUV_CONTROL_THRUSTERFORCE2BODYEFFORT_TASK_HPP
+#define AUV_CONTROL_THRUSTERFORCE2BODYEFFORT_TASK_HPP
+
+#include "auv_control/ThrusterForce2BodyEffortBase.hpp"
+
+namespace auv_control{
+
+    /*! \class ThrusterForce2BodyEffort
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * Task that converts thruster's feedback from rpm to force.
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','auv_control::ThrusterForce2BodyEffort')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     */
+    class ThrusterForce2BodyEffort : public ThrusterForce2BodyEffortBase
+    {
+	friend class ThrusterForce2BodyEffortBase;
+    protected:
+
+	    base::MatrixXd thrusterMatrix;
+
+    public:
+        /** TaskContext constructor for ThrusterForce2BodyEffort
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        ThrusterForce2BodyEffort(std::string const& name = "auv_control::ThrusterForce2BodyEffort");
+
+        /** TaskContext constructor for ThrusterForce2BodyEffort
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         * 
+         */
+        ThrusterForce2BodyEffort(std::string const& name, RTT::ExecutionEngine* engine);
+
+        /** Default deconstructor of ThrusterForce2BodyEffort
+         */
+	~ThrusterForce2BodyEffort();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+

--- a/tasks/ThrustersBase.cpp
+++ b/tasks/ThrustersBase.cpp
@@ -1,0 +1,167 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ThrustersBase.hpp"
+#include "base/Logging.hpp"
+
+using namespace auv_control;
+
+ThrustersBase::ThrustersBase(std::string const& name)
+    : ThrustersBaseBase(name)
+{
+}
+
+ThrustersBase::ThrustersBase(std::string const& name, RTT::ExecutionEngine* engine)
+    : ThrustersBaseBase(name, engine)
+{
+}
+
+ThrustersBase::~ThrustersBase()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ThrustersBase.hpp for more detailed
+// documentation about them.
+
+bool ThrustersBase::configureHook()
+{
+    if (! ThrustersBaseBase::configureHook())
+        return false;
+
+    thrusterVoltage     = _thruster_voltage.get();
+    coeffPos            = _thruster_coeff_pos.get();
+    coeffNeg            = _thruster_coeff_neg.get();
+    controlModes        = _control_modes.get();
+    numberOfThrusters = controlModes.size();
+
+    // In case the control_modes vector was set
+    if(numberOfThrusters != 0)
+    {
+        // Checks if the three arrays have the same length
+        if(coeffPos.size() != numberOfThrusters || coeffNeg.size() != numberOfThrusters)
+        {
+            LOG_ERROR("The size of control_modes, thruster_coeff_pos and "
+                    "thruster_coeff_neg do not agree (control_modes: %i, "
+                    "thruster_coeff_pos: %i, thruster_coeff_neg: %i)",
+                    numberOfThrusters, coeffPos.size(), coeffNeg.size());
+            return false;
+        }
+    }
+    // In case control_modes wasn't set, checks if the other two arrays have the same length
+    else if(coeffPos.size() != coeffNeg.size())
+    {
+        LOG_ERROR("The size of control_modes, thruster_coeff_pos and "
+                "thruster_coeff_neg do not agree (control_modes: %i, "
+                "thruster_coeff_pos: %i, thruster_coeff_neg: %i)",
+                numberOfThrusters, coeffPos.size(), coeffNeg.size());
+        return false;
+    }
+    // In case control_modes wasn't set but the other two arrays have the same length
+    else
+    {
+        LOG_WARN("The control_modes is being automatically set to RAW, "
+                 "since it wasn't previously set.");
+        numberOfThrusters = coeffPos.size();
+        controlModes.resize(numberOfThrusters, base::JointState::RAW);
+        _control_modes.set(controlModes);
+    }
+
+    for (uint i = 0; i < numberOfThrusters; i++)
+    {
+        // A different JointState other than SPEED and RAW was chosen
+        if(controlModes[i] !=  base::JointState::SPEED && controlModes[i] !=  base::JointState::RAW)
+        {
+            LOG_ERROR("Control mode should be either SPEED or RAW.");
+            return false;
+        }
+        // When using RAW control mode, the calculation demands that the thruster voltage
+        // is set, and the latest can only assume positive values
+        if(controlModes[i] ==  base::JointState::RAW && thrusterVoltage <= 0)
+        {
+            LOG_ERROR("The control mode was set to RAW, but no positive value was assigned "
+                    "to thruster_voltage.");
+            return false;
+        }
+        // The thruster coefficients can only assume positive values
+        if (coeffPos[i] <= 0 || coeffNeg[i] <= 0)
+        {
+            LOG_ERROR("The thrusters coefficients (both positive and negative) should only "
+                    "have positive values.");
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ThrustersBase::startHook()
+{
+    if (! ThrustersBaseBase::startHook())
+        return false;
+    return true;
+}
+void ThrustersBase::updateHook()
+{
+    ThrustersBaseBase::updateHook();
+}
+void ThrustersBase::errorHook()
+{
+    ThrustersBaseBase::errorHook();
+}
+void ThrustersBase::stopHook()
+{
+    ThrustersBaseBase::stopHook();
+}
+void ThrustersBase::cleanupHook()
+{
+    ThrustersBaseBase::cleanupHook();
+}
+bool ThrustersBase::checkControlInput(base::samples::Joints const &cmd_in, base::JointState::MODE mode)
+{
+    std::string textElement;
+
+    // No match between input.size and the expected number of thrusters
+    if(cmd_in.elements.size() != numberOfThrusters)
+    {
+        LOG_ERROR("The input vector should have a size equal to %i, but actually it "
+                "has size equal to %i. Check configuration. ", numberOfThrusters, cmd_in.elements.size());
+        exception(UNEXPECTED_THRUSTER_INPUT);
+        return false;
+    }
+
+    for (uint i = 0; i < numberOfThrusters; i++)
+    {
+        // Verify if the desired mode field is a NaN
+        if (base::isNaN(cmd_in.elements[i].getField(mode)))
+        {
+            // Define how to call the problematic thruster
+            std::string textMode;
+            std::string textThruster;
+
+            // Check whether names were specified for the thrusters
+            if(cmd_in.names.size() == numberOfThrusters)
+                textThruster = cmd_in.names[i];
+            else
+            {
+                std::stringstream number;
+                number << i;
+                textThruster = number.str();
+            }
+
+            if(mode == base::JointState::SPEED)
+                textMode = "SPEED";
+            else if(mode == base::JointState::RAW)
+                textMode = "RAW";
+            else if(mode == base::JointState::EFFORT)
+                textMode = "EFFORT";
+            else
+                textMode = "unsupported mode";
+
+            LOG_ERROR("The field %s of the thruster %s was not set.", textMode.c_str(), textThruster.c_str());
+            exception(UNSET_THRUSTER_INPUT);
+            return false;
+        }
+    }
+    return true;
+}

--- a/tasks/ThrustersBase.hpp
+++ b/tasks/ThrustersBase.hpp
@@ -1,52 +1,57 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
 
-#ifndef AUV_CONTROL_THRUSTERSINPUT_TASK_HPP
-#define AUV_CONTROL_THRUSTERSINPUT_TASK_HPP
+#ifndef AUV_CONTROL_THRUSTERSBASE_TASK_HPP
+#define AUV_CONTROL_THRUSTERSBASE_TASK_HPP
 
-#include "auv_control/ThrustersInputBase.hpp"
+#include "auv_control/ThrustersBaseBase.hpp"
 
-namespace auv_control {
+namespace auv_control{
 
-    /*! \class ThrustersInput 
+    /*! \class ThrustersBase
      * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
      * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
      * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
      * Task that convert forces[N] to thruster's control signal.
-Receive as input AccelerationController.cmd_out and gives as output the control signal for each thruster
+Receive as input AccelerationController.cmd_out and gives as output the control signal to the thruster's driver
 Configure the kind of control signal and thruster's properties
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
      deployment 'deployment_name'
-         task('custom_task_name','auv_control::ThrustersInput')
+         task('custom_task_name','auv_control::ThrustersBase')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
      */
-    class ThrustersInput : public ThrustersInputBase
+    class ThrustersBase : public ThrustersBaseBase
     {
-	friend class ThrustersInputBase;
+	friend class ThrustersBaseBase;
     protected:
 
-        base::samples::Joints calcOutput(base::samples::Joints const &thruster_forces) const;
+        base::VectorXd coeffPos;
+        base::VectorXd coeffNeg;
+        std::vector<base::JointState::MODE> controlModes;
+        double thrusterVoltage;
+        uint numberOfThrusters;
+        bool checkControlInput(base::samples::Joints const &cmd_in, base::JointState::MODE mode);
 
     public:
-        /** TaskContext constructor for ThrustersInput
+        /** TaskContext constructor for ThrustersBase
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        ThrustersInput(std::string const& name = "auv_control::ThrustersInput");
+        ThrustersBase(std::string const& name = "auv_control::ThrustersBase");
 
-        /** TaskContext constructor for ThrustersInput 
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+        /** TaskContext constructor for ThrustersBase
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
          * 
          */
-        ThrustersInput(std::string const& name, RTT::ExecutionEngine* engine);
+        ThrustersBase(std::string const& name, RTT::ExecutionEngine* engine);
 
-        /** Default deconstructor of ThrustersInput
+        /** Default deconstructor of ThrustersBase
          */
-	~ThrustersInput();
+	~ThrustersBase();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -77,7 +82,7 @@ Configure the kind of control signal and thruster's properties
          *
          * The error(), exception() and fatal() calls, when called in this hook,
          * allow to get into the associated RunTimeError, Exception and
-         * FatalError states. 
+         * FatalError states.
          *
          * In the first case, updateHook() is still called, and recover() allows
          * you to go back into the Running state.  In the second case, the

--- a/tasks/ThrustersFeedback.cpp
+++ b/tasks/ThrustersFeedback.cpp
@@ -1,0 +1,98 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ThrustersFeedback.hpp"
+#include "base/commands/Joints.hpp"
+
+using namespace auv_control;
+
+ThrustersFeedback::ThrustersFeedback(std::string const& name)
+    : ThrustersFeedbackBase(name)
+{
+}
+
+ThrustersFeedback::ThrustersFeedback(std::string const& name, RTT::ExecutionEngine* engine)
+    : ThrustersFeedbackBase(name, engine)
+{
+}
+
+ThrustersFeedback::~ThrustersFeedback()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ThrustersFeedback.hpp for more detailed
+// documentation about them.
+
+bool ThrustersFeedback::configureHook()
+{
+    if (! ThrustersFeedbackBase::configureHook())
+        return false;
+    return true;
+}
+bool ThrustersFeedback::startHook()
+{
+    if (! ThrustersFeedbackBase::startHook())
+        return false;
+    return true;
+}
+void ThrustersFeedback::updateHook()
+{
+    base::commands::Joints joint_samples;
+    if(_joint_samples_in.read(joint_samples) == RTT::NewData)
+    {
+        if(ThrustersInput::checkControlInput(joint_samples, controlModes[0]))
+        {
+            base::commands::Joints output = calcOutput(joint_samples);
+            _forces_out.write(output);
+        }
+    }
+}
+void ThrustersFeedback::errorHook()
+{
+    ThrustersFeedbackBase::errorHook();
+}
+void ThrustersFeedback::stopHook()
+{
+    ThrustersFeedbackBase::stopHook();
+}
+void ThrustersFeedback::cleanupHook()
+{
+    ThrustersFeedbackBase::cleanupHook();
+}
+
+base::samples::Joints ThrustersFeedback::calcOutput(base::samples::Joints const &joint_samples) const
+{
+    base::samples::Joints forces;
+    forces.elements.resize(numberOfThrusters);
+    base::VectorXd feedback = base::VectorXd::Zero(numberOfThrusters);
+
+    for (uint i = 0; i < numberOfThrusters; i++)
+    {
+        // Force = Cv * Speed * |Speed|
+        if(controlModes[i] == base::JointState::SPEED)
+        {
+            feedback[i] = joint_samples.elements[i].speed;
+            if(joint_samples.elements[i].speed >= 0)
+                forces.elements[i].effort = coeffPos[i] * feedback[i] * fabs(feedback[i]);
+            else
+                forces.elements[i].effort = coeffNeg[i] * feedback[i] * fabs(feedback[i]);
+        }
+        // Force = Cv * V * |V|
+        // V = pwm * thrusterVoltage
+        else if(controlModes[i] == base::JointState::RAW)
+        {
+            feedback[i] = joint_samples.elements[i].raw * thrusterVoltage;
+            if(joint_samples.elements[i].speed >= 0)
+                forces.elements[i].effort = coeffPos[i] * feedback[i] * fabs(feedback[i]);
+            else
+                forces.elements[i].effort = coeffNeg[i] * feedback[i] * fabs(feedback[i]);
+        }
+    }
+
+    forces.time = joint_samples.time;
+    forces.names = joint_samples.names;
+
+    return forces;
+}

--- a/tasks/ThrustersFeedback.cpp
+++ b/tasks/ThrustersFeedback.cpp
@@ -40,7 +40,7 @@ bool ThrustersFeedback::startHook()
 void ThrustersFeedback::updateHook()
 {
     base::commands::Joints jointSamples;
-    if(_cmd_in.read(jointSamples) == RTT::NewData)
+    while(_cmd_in.read(jointSamples) == RTT::NewData)
     {
         if(ThrustersBase::checkControlInput(jointSamples, controlModes[0]))
         {

--- a/tasks/ThrustersFeedback.hpp
+++ b/tasks/ThrustersFeedback.hpp
@@ -26,8 +26,7 @@ namespace auv_control{
 	friend class ThrustersFeedbackBase;
     protected:
 
-	    base::samples::Joints calcOutput(base::samples::Joints const &joint_samples) const;
-	    bool checkControlInput(base::samples::Joints const &cmd_in);
+	    base::samples::Joints calcOutput(base::samples::Joints const &thruster_rotations) const;
 
     public:
         /** TaskContext constructor for ThrustersFeedback

--- a/tasks/ThrustersFeedback.hpp
+++ b/tasks/ThrustersFeedback.hpp
@@ -1,0 +1,111 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef AUV_CONTROL_THRUSTERSFEEDBACK_TASK_HPP
+#define AUV_CONTROL_THRUSTERSFEEDBACK_TASK_HPP
+
+#include "auv_control/ThrustersFeedbackBase.hpp"
+
+namespace auv_control{
+
+    /*! \class ThrustersFeedback
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * Task that converts thruster's feedback from rpm to force.
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','auv_control::ThrustersFeedback')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     */
+    class ThrustersFeedback : public ThrustersFeedbackBase
+    {
+	friend class ThrustersFeedbackBase;
+    protected:
+
+	    base::samples::Joints calcOutput(base::samples::Joints const &joint_samples) const;
+	    bool checkControlInput(base::samples::Joints const &cmd_in);
+
+    public:
+        /** TaskContext constructor for ThrustersFeedback
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        ThrustersFeedback(std::string const& name = "auv_control::ThrustersFeedback");
+
+        /** TaskContext constructor for ThrustersFeedback
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         * 
+         */
+        ThrustersFeedback(std::string const& name, RTT::ExecutionEngine* engine);
+
+        /** Default deconstructor of ThrustersFeedback
+         */
+	~ThrustersFeedback();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+

--- a/tasks/ThrustersInput.cpp
+++ b/tasks/ThrustersInput.cpp
@@ -2,7 +2,6 @@
 
 #include "ThrustersInput.hpp"
 #include "base/commands/Joints.hpp"
-#include "base/Logging.hpp"
 
 using namespace auv_control;
 
@@ -30,71 +29,6 @@ bool ThrustersInput::configureHook()
 {
     if (! ThrustersInputBase::configureHook())
         return false;
-
-    thrusterVoltage		= _thruster_voltage.get();
-    coeffPos 			= _thruster_coeff_pos.get();
-    coeffNeg 			= _thruster_coeff_neg.get();
-    controlModes		= _control_modes.get();
-
-    numberOfThrusters = controlModes.size();
-
-    // In case the control_modes vector was set
-    if(numberOfThrusters != 0)
-    {
-        // Checks if the three arrays have the same length
-        if(coeffPos.size() != numberOfThrusters || coeffNeg.size() != numberOfThrusters)
-        {
-            LOG_ERROR("The size of control_modes, thruster_coeff_pos and "
-                    "thruster_coeff_neg do not agree (control_modes: %i, "
-                    "thruster_coeff_pos: %i, thruster_coeff_neg: %i)",
-                    numberOfThrusters, coeffPos.size(), coeffNeg.size());
-            return false;
-        }
-    }
-    // In case control_modes wasn't set, checks if the other two arrays have the same length
-    else if(coeffPos.size() != coeffNeg.size())
-    {
-        LOG_ERROR("The size of control_modes, thruster_coeff_pos and "
-                "thruster_coeff_neg do not agree (control_modes: %i, "
-                "thruster_coeff_pos: %i, thruster_coeff_neg: %i)",
-                numberOfThrusters, coeffPos.size(), coeffNeg.size());
-        return false;
-    }
-    // In case control_modes wasn't set but the other two arrays have the same length
-    else
-    {
-        LOG_WARN("The control_modes is being automatically set to RAW, "
-                 "since it wasn't previously set.");
-        numberOfThrusters = coeffPos.size();
-        controlModes.resize(numberOfThrusters, base::JointState::RAW);
-        _control_modes.set(controlModes);
-    }
-
-    for (uint i = 0; i < numberOfThrusters; i++)
-    {
-        // A different JointState other than SPEED and RAW was chosen
-        if(controlModes[i] !=  base::JointState::SPEED && controlModes[i] !=  base::JointState::RAW)
-        {
-            LOG_ERROR("Control mode should be either SPEED or RAW.");
-            return false;
-        }
-        // When using RAW control mode, the calculation demands that the thruster voltage
-        // is set, and the latest can only assume positive values
-        if(controlModes[i] ==  base::JointState::RAW && thrusterVoltage <= 0)
-        {
-            LOG_ERROR("The control mode was set to RAW, but no positive value was assigned "
-                    "to thruster_voltage.");
-            return false;
-        }
-        // The thruster coefficients can only assume positive values
-        if (coeffPos[i] <= 0 || coeffNeg[i] <= 0)
-        {
-            LOG_ERROR("The thrusters coefficients (both positive and negative) should only "
-                    "have positive values.");
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -108,16 +42,15 @@ void ThrustersInput::updateHook()
 {
     ThrustersInputBase::updateHook();
 
-    base::commands::Joints input;
-    if(_cmd_in.read(input) == RTT::NewData)
+    base::commands::Joints thrusterForces;
+    if(_cmd_in.read(thrusterForces) == RTT::NewData)
     {
-        if(checkControlInput(input, base::JointState::EFFORT))
+        if(ThrustersBase::checkControlInput(thrusterForces, base::JointState::EFFORT))
         {
-            base::commands::Joints output = calcOutput(input);
-            _cmd_out.write(output);
+            base::commands::Joints thrusterCommands = calcOutput(thrusterForces);
+            _cmd_out.write(thrusterCommands);
         }
     }
-
 }
 void ThrustersInput::errorHook()
 {
@@ -132,83 +65,32 @@ void ThrustersInput::cleanupHook()
     ThrustersInputBase::cleanupHook();
 }
 
-bool ThrustersInput::checkControlInput(base::samples::Joints const &cmd_in, base::JointState::MODE mode)
+base::samples::Joints ThrustersInput::calcOutput(base::samples::Joints const &thrusterForces) const
 {
-    std::string textElement;
-
-    // No match between input.size and the expected number of thrusters
-    if(cmd_in.elements.size() != numberOfThrusters)
-    {
-        LOG_ERROR("The input vector should have a size equal to %i, but actually it "
-                "has size equal to %i. Check configuration. ", numberOfThrusters, cmd_in.elements.size());
-        exception(UNEXPECTED_THRUSTER_INPUT);
-        return false;
-    }
-
-    for (uint i = 0; i < numberOfThrusters; i++)
-    {
-        // Verify if the desired mode field is a NaN
-        if (base::isNaN(cmd_in.elements[i].getField(mode)))
-        {
-            // Define how to call the problematic thruster
-            std::string textMode;
-            std::string textThruster;
-
-            // Check whether names were specified for the thrusters
-            if(cmd_in.names.size() == numberOfThrusters)
-                textThruster = cmd_in.names[i];
-            else
-            {
-                std::stringstream number;
-                number << i;
-                textThruster = number.str();
-            }
-
-            if(mode == base::JointState::SPEED)
-                textMode = "SPEED";
-            else if(mode == base::JointState::RAW)
-                textMode = "RAW";
-            else if(mode == base::JointState::EFFORT)
-                textMode = "EFFORT";
-            else
-                textMode = "unsupported mode";
-
-            LOG_ERROR("The field %s of the thruster %s was not set.", textMode.c_str(), textThruster.c_str());
-            exception(UNSET_THRUSTER_INPUT);
-            return false;
-        }
-
-    }
-    // In case of all inputs have valid values
-    return true;
-}
-
-base::samples::Joints ThrustersInput::calcOutput(base::samples::Joints const &cmd_in) const
-{
-    base::samples::Joints cmd_out;
-    cmd_out.elements.resize(numberOfThrusters);
+    base::samples::Joints thrusterCommands;
+    thrusterCommands.elements.resize(numberOfThrusters);
     for (uint i = 0; i < numberOfThrusters; i++)
     {
         // Force = Cv * Speed * |Speed|
         if(controlModes[i] == base::JointState::SPEED)
         {
-            if(cmd_in.elements[i].effort >= 0)
-                cmd_out.elements[i].speed = + sqrt(fabs(cmd_in.elements[i].effort) / coeffPos[i]);
+            if(thrusterForces.elements[i].effort >= 0)
+                thrusterCommands.elements[i].speed = + sqrt(fabs(thrusterForces.elements[i].effort) / coeffPos[i]);
             else
-                cmd_out.elements[i].speed = - sqrt(fabs(cmd_in.elements[i].effort) / coeffNeg[i]);
+                thrusterCommands.elements[i].speed = - sqrt(fabs(thrusterForces.elements[i].effort) / coeffNeg[i]);
         }
         // Force = Cv * V * |V|
         // V = pwm * thrusterVoltage
         else if(controlModes[i] == base::JointState::RAW)
         {
-            if(cmd_in.elements[i].effort >= 0)
-                cmd_out.elements[i].raw = + sqrt(fabs(cmd_in.elements[i].effort / coeffPos[i])) / thrusterVoltage;
+            if(thrusterForces.elements[i].effort >= 0)
+                thrusterCommands.elements[i].raw = + sqrt(fabs(thrusterForces.elements[i].effort / coeffPos[i])) / thrusterVoltage;
             else
-                cmd_out.elements[i].raw = - sqrt(fabs(cmd_in.elements[i].effort / coeffNeg[i])) / thrusterVoltage;
+                thrusterCommands.elements[i].raw = - sqrt(fabs(thrusterForces.elements[i].effort / coeffNeg[i])) / thrusterVoltage;
         }
     }
-    cmd_out.time = cmd_in.time;
-    cmd_out.names = cmd_in.names;
-    return cmd_out;
+    thrusterCommands.time = thrusterForces.time;
+    thrusterCommands.names = thrusterForces.names;
+    return thrusterCommands;
 }
 

--- a/tasks/ThrustersInput.cpp
+++ b/tasks/ThrustersInput.cpp
@@ -43,7 +43,7 @@ void ThrustersInput::updateHook()
     ThrustersInputBase::updateHook();
 
     base::commands::Joints thrusterForces;
-    if(_cmd_in.read(thrusterForces) == RTT::NewData)
+    while(_cmd_in.read(thrusterForces) == RTT::NewData)
     {
         if(ThrustersBase::checkControlInput(thrusterForces, base::JointState::EFFORT))
         {

--- a/tasks/ThrustersInput.hpp
+++ b/tasks/ThrustersInput.hpp
@@ -28,14 +28,14 @@ Configure the kind of control signal and thruster's properties
 	friend class ThrustersInputBase;
     protected:
 
-	base::VectorXd coeffPos;
+	    base::VectorXd coeffPos;
         base::VectorXd coeffNeg;
         std::vector<base::JointState::MODE> controlModes;
         double thrusterVoltage;
         uint numberOfThrusters;
 
         base::samples::Joints calcOutput(base::samples::Joints const &cmd_in) const;
-	bool checkControlInput(base::samples::Joints const &cmd_in);
+        bool checkControlInput(base::samples::Joints const &cmd_in, base::JointState::MODE mode);
 
     public:
         /** TaskContext constructor for ThrustersInput

--- a/test/auv_control::ThrusterForce2BodyEffort.yml
+++ b/test/auv_control::ThrusterForce2BodyEffort.yml
@@ -1,0 +1,44 @@
+--- name:default
+# Matrix with size of 6 * n. n means the count of thrusters that are used.
+# The rows 0 to 2 of the matrix are the linear axis. The lines 3 to 5 of the
+# matrix are the angular axis.
+thruster_configuration_matrix:
+  rows: 6
+  cols: 6
+  data:
+  - 1.0
+  - 0.0
+  - 0.0
+  - 0.0
+  - 0.0
+  - -0.42
+  - 1.0
+  - 0.0
+  - 0.0
+  - 0.0
+  - 0.0
+  - 0.42
+  - 0.0
+  - -1.0
+  - 0.0
+  - 0.0
+  - 0.0
+  - -0.5735
+  - 0.0
+  - -1.0
+  - 0.0
+  - -0.0
+  - 0.0
+  - 0.936
+  - 0.0
+  - 0.0
+  - -1.0
+  - 0.0
+  - 0.4235
+  - 0.0
+  - 0.0
+  - 0.0
+  - -1.0
+  - -0.0
+  - -0.556
+  - 0.0

--- a/test/auv_control::ThrustersFeedback.yml
+++ b/test/auv_control::ThrustersFeedback.yml
@@ -1,0 +1,31 @@
+--- name:default
+# If left empty, uses RAW by default
+control_modes: [RAW, RAW]
+# Convert thruster signal into forces, in negative direction or CCW.
+# Should have a size equal to the number of actuators
+# Thruster[N] = Coeff * rotation * |rotation|
+thruster_coeff_neg:
+  data: [6.698667e-5, 6.698667e-5]
+# Convert thruster signal into forces, in positive direction or CW.
+# Should have a size equal to the number of actuators
+# Thruster[N] = Coeff * rotation * |rotation|
+thruster_coeff_pos:
+  data: [6.698667e-5, 6.698667e-5]
+# In case the control_modes is RAW (pwm), used to convert the signal into DC Voltage
+# Thruster[N] = Coeff * voltage * |voltage|
+thruster_voltage: 19
+
+--- name:control_mode_3_raw
+control_modes: [RAW, RAW, RAW]
+
+--- name:thruster_coeff_pos_size_3
+thruster_coeff_pos:
+  data: [10, 10, 10]
+  
+--- name:control_modes_effort
+# If left empty, uses RAW by default
+control_modes: [EFFORT, EFFORT]
+
+--- name:control_modes_speed
+# If left empty, uses RAW by default
+control_modes: [SPEED, SPEED]

--- a/test/test_thruster_feedback.rb
+++ b/test/test_thruster_feedback.rb
@@ -33,14 +33,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
   it 'wrong control_modes size' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_mode_3_raw'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'control_mode_3_raw'], true)
     
     assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
   end
 
   it 'wrong thruster_coeff_pos size' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'thruster_coeff_pos_size_3'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'thruster_coeff_pos_size_3'], true)
     
     assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
   end
@@ -58,7 +60,8 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
   it 'pos and neg coefficients have different sizes' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'thruster_coeff_pos_size_3'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'thruster_coeff_pos_size_3'], true)
     
     aux = thrusters_feedback.control_modes
     aux.clear
@@ -69,7 +72,8 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
   it 'control modes set to EFFORT' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_effort'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'control_modes_effort'], true)
     
     assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
   end
@@ -99,7 +103,6 @@ describe 'auv_control::ThrustersFeedback configuration' do
     cmd_in.write sample
 
     assert_state_change(thrusters_feedback) { |s| s == :UNEXPECTED_THRUSTER_INPUT } 
-        
   end
   
   it 'thruster input not set' do
@@ -117,12 +120,12 @@ describe 'auv_control::ThrustersFeedback configuration' do
     cmd_in.write sample
 
     assert_state_change(thrusters_feedback) { |s| s == :UNSET_THRUSTER_INPUT } 
-        
   end
   
   it 'testing positive speed calculated value' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_speed'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'control_modes_speed'], true)
     
     thrusters_feedback.configure  
     thrusters_feedback.start  
@@ -138,14 +141,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
     data = assert_has_one_new_sample cmd_out, 1
     
-    assert (data.elements[0].effort - 13.99).abs < 0.001
-    assert (data.elements[1].effort - 41.701).abs < 0.001
-        
+    assert_in_delta data.elements[0].effort, 13.99, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].effort, 41.701, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing negative speed calculated value' do
 
-    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_speed'], true)
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",
+        ['default', 'control_modes_speed'], true)
     
     thrusters_feedback.configure  
     thrusters_feedback.start  
@@ -161,9 +166,10 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
     data = assert_has_one_new_sample cmd_out, 1
     
-    assert (data.elements[0].effort + 18.817).abs < 0.001
-    assert (data.elements[1].effort + 28.302).abs < 0.001
-        
+    assert_in_delta data.elements[0].effort, -18.817, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].effort, -28.302, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing positive raw calculated value' do
@@ -184,8 +190,10 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
     data = assert_has_one_new_sample cmd_out, 1
     
-    assert (data.elements[0].effort - 15.114).abs < 0.001
-    assert (data.elements[1].effort - 6.9887).abs < 0.001
+    assert_in_delta data.elements[0].effort, 15.114, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].effort, 6.9887, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing negative raw calculated value' do
@@ -206,8 +214,10 @@ describe 'auv_control::ThrustersFeedback configuration' do
 
     data = assert_has_one_new_sample cmd_out, 1
     
-    assert (data.elements[0].effort + 58.061).abs < 0.001
-    assert (data.elements[1].effort + 23.239).abs < 0.001
+    assert_in_delta data.elements[0].effort, -58.061, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].effort, -23.239, 0.001,
+        "wrong expected value for thruster 2"
   end
 
 end

--- a/test/test_thruster_feedback.rb
+++ b/test/test_thruster_feedback.rb
@@ -6,8 +6,8 @@ require 'minitest/autorun'
 describe 'auv_control::ThrustersFeedback configuration' do
   include Orocos::Test::Component
   start  'thrusters_feedback', 'auv_control::ThrustersFeedback' => 'thrusters_feedback'
-  reader 'thrusters_feedback', 'forces_out', :attr_name => 'forces_out'
-  writer 'thrusters_feedback', 'joint_samples_in', :attr_name => 'joint_samples_in'
+  reader 'thrusters_feedback', 'cmd_out', :attr_name => 'cmd_out'
+  writer 'thrusters_feedback', 'cmd_in', :attr_name => 'cmd_in'
 
   it 'thruster_coeff_pos < 0' do
 
@@ -90,13 +90,13 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
       
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
     
     # 3 thrusters inputs were sent and 2 are expected
     thruster = Types::Base::JointState.new
     thruster.effort = 3
     sample.elements = [thruster, thruster, thruster]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
     assert_state_change(thrusters_feedback) { |s| s == :UNEXPECTED_THRUSTER_INPUT } 
         
@@ -109,12 +109,12 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
 
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
       
     # the effort field was not set
     thruster = Types::Base::JointState.new
     sample.elements = [thruster, thruster]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
     assert_state_change(thrusters_feedback) { |s| s == :UNSET_THRUSTER_INPUT } 
         
@@ -127,16 +127,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
 
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
       
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.speed = 457
     thruster2.speed = 789
     sample.elements = [thruster1, thruster2]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
-    data = assert_has_one_new_sample forces_out, 1
+    data = assert_has_one_new_sample cmd_out, 1
     
     assert (data.elements[0].effort - 13.99).abs < 0.001
     assert (data.elements[1].effort - 41.701).abs < 0.001
@@ -150,16 +150,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
 
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
       
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.speed = -530
     thruster2.speed = -650
     sample.elements = [thruster1, thruster2]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
-    data = assert_has_one_new_sample forces_out, 1
+    data = assert_has_one_new_sample cmd_out, 1
     
     assert (data.elements[0].effort + 18.817).abs < 0.001
     assert (data.elements[1].effort + 28.302).abs < 0.001
@@ -173,16 +173,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
 
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
       
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.raw = 25
     thruster2.raw = 17
     sample.elements = [thruster1, thruster2]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
-    data = assert_has_one_new_sample forces_out, 1
+    data = assert_has_one_new_sample cmd_out, 1
     
     assert (data.elements[0].effort - 15.114).abs < 0.001
     assert (data.elements[1].effort - 6.9887).abs < 0.001
@@ -195,16 +195,16 @@ describe 'auv_control::ThrustersFeedback configuration' do
     thrusters_feedback.configure  
     thrusters_feedback.start  
 
-    sample = thrusters_feedback.joint_samples_in.new_sample
+    sample = thrusters_feedback.cmd_in.new_sample
       
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.raw = -49
     thruster2.raw = -31
     sample.elements = [thruster1, thruster2]
-    joint_samples_in.write sample 
+    cmd_in.write sample
 
-    data = assert_has_one_new_sample forces_out, 1
+    data = assert_has_one_new_sample cmd_out, 1
     
     assert (data.elements[0].effort + 58.061).abs < 0.001
     assert (data.elements[1].effort + 23.239).abs < 0.001

--- a/test/test_thruster_feedback.rb
+++ b/test/test_thruster_feedback.rb
@@ -1,0 +1,214 @@
+require 'minitest/spec'
+require 'orocos/test/component'
+require 'minitest/autorun'
+
+
+describe 'auv_control::ThrustersFeedback configuration' do
+  include Orocos::Test::Component
+  start  'thrusters_feedback', 'auv_control::ThrustersFeedback' => 'thrusters_feedback'
+  reader 'thrusters_feedback', 'forces_out', :attr_name => 'forces_out'
+  writer 'thrusters_feedback', 'joint_samples_in', :attr_name => 'joint_samples_in'
+
+  it 'thruster_coeff_pos < 0' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+
+    aux = thrusters_feedback.thruster_coeff_pos
+    aux[0] = -8
+    thrusters_feedback.thruster_coeff_pos = aux
+      
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'thruster_coeff_neg < 0' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+
+    aux = thrusters_feedback.thruster_coeff_neg
+    aux[0] = -8
+    thrusters_feedback.thruster_coeff_neg = aux
+      
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'wrong control_modes size' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_mode_3_raw'], true)
+    
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'wrong thruster_coeff_pos size' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'thruster_coeff_pos_size_3'], true)
+    
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'automatically setting control_modes' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    aux = thrusters_feedback.control_modes
+    aux.clear
+    thrusters_feedback.control_modes = aux 
+      
+    thrusters_feedback.configure
+  end
+
+  it 'pos and neg coefficients have different sizes' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'thruster_coeff_pos_size_3'], true)
+    
+    aux = thrusters_feedback.control_modes
+    aux.clear
+    thrusters_feedback.control_modes = aux 
+      
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'control modes set to EFFORT' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_effort'], true)
+    
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'control mode equals to RAW but no thruster voltage was set' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    thrusters_feedback.thruster_voltage = 0
+    
+    assert_raises(Orocos::StateTransitionFailed) { thrusters_feedback.configure }
+  end
+
+  it 'wrong number of thrusters input' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+      
+    sample = thrusters_feedback.joint_samples_in.new_sample
+    
+    # 3 thrusters inputs were sent and 2 are expected
+    thruster = Types::Base::JointState.new
+    thruster.effort = 3
+    sample.elements = [thruster, thruster, thruster]
+    joint_samples_in.write sample 
+
+    assert_state_change(thrusters_feedback) { |s| s == :UNEXPECTED_THRUSTER_INPUT } 
+        
+  end
+  
+  it 'thruster input not set' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+
+    sample = thrusters_feedback.joint_samples_in.new_sample
+      
+    # the effort field was not set
+    thruster = Types::Base::JointState.new
+    sample.elements = [thruster, thruster]
+    joint_samples_in.write sample 
+
+    assert_state_change(thrusters_feedback) { |s| s == :UNSET_THRUSTER_INPUT } 
+        
+  end
+  
+  it 'testing positive speed calculated value' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_speed'], true)
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+
+    sample = thrusters_feedback.joint_samples_in.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster1.speed = 457
+    thruster2.speed = 789
+    sample.elements = [thruster1, thruster2]
+    joint_samples_in.write sample 
+
+    data = assert_has_one_new_sample forces_out, 1
+    
+    assert (data.elements[0].effort - 13.99).abs < 0.001
+    assert (data.elements[1].effort - 41.701).abs < 0.001
+        
+  end
+
+  it 'testing negative speed calculated value' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml",['default', 'control_modes_speed'], true)
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+
+    sample = thrusters_feedback.joint_samples_in.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster1.speed = -530
+    thruster2.speed = -650
+    sample.elements = [thruster1, thruster2]
+    joint_samples_in.write sample 
+
+    data = assert_has_one_new_sample forces_out, 1
+    
+    assert (data.elements[0].effort + 18.817).abs < 0.001
+    assert (data.elements[1].effort + 28.302).abs < 0.001
+        
+  end
+
+  it 'testing positive raw calculated value' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+
+    sample = thrusters_feedback.joint_samples_in.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster1.raw = 25
+    thruster2.raw = 17
+    sample.elements = [thruster1, thruster2]
+    joint_samples_in.write sample 
+
+    data = assert_has_one_new_sample forces_out, 1
+    
+    assert (data.elements[0].effort - 15.114).abs < 0.001
+    assert (data.elements[1].effort - 6.9887).abs < 0.001
+  end
+
+  it 'testing negative raw calculated value' do
+
+    thrusters_feedback.apply_conf_file("auv_control::ThrustersFeedback.yml")
+    
+    thrusters_feedback.configure  
+    thrusters_feedback.start  
+
+    sample = thrusters_feedback.joint_samples_in.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster1.raw = -49
+    thruster2.raw = -31
+    sample.elements = [thruster1, thruster2]
+    joint_samples_in.write sample 
+
+    data = assert_has_one_new_sample forces_out, 1
+    
+    assert (data.elements[0].effort + 58.061).abs < 0.001
+    assert (data.elements[1].effort + 23.239).abs < 0.001
+  end
+
+end
+

--- a/test/test_thruster_force_2_body_effort.rb
+++ b/test/test_thruster_force_2_body_effort.rb
@@ -1,0 +1,82 @@
+require 'minitest/spec'
+require 'orocos/test/component'
+require 'minitest/autorun'
+
+
+describe 'auv_control::ThrusterForce2BodyEffort configuration' do
+  include Orocos::Test::Component
+  start 'thruster_force_2_body_effort', 'auv_control::ThrusterForce2BodyEffort' => 'thruster_force_2_body_effort'
+  reader 'thruster_force_2_body_effort', 'body_efforts', :attr_name => 'body_efforts'
+  writer 'thruster_force_2_body_effort', 'thruster_forces', :attr_name => 'thruster_forces'
+
+
+  it 'testing thruster surge and yaw force values' do
+
+    thruster_force_2_body_effort.apply_conf_file("auv_control::ThrusterForce2BodyEffort.yml")
+
+    thruster_force_2_body_effort.configure  
+    thruster_force_2_body_effort.start  
+
+    sample = thruster_force_2_body_effort.thruster_forces.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster3 = Types::Base::JointState.new
+    thruster4 = Types::Base::JointState.new
+    thruster5 = Types::Base::JointState.new
+    thruster6 = Types::Base::JointState.new
+    thruster1.effort = 30
+    thruster2.effort = 30
+    thruster3.effort = 0
+    thruster4.effort = 0
+    thruster5.effort = 50
+    thruster6.effort = 50
+    
+    sample.elements = [thruster1, thruster2, thruster3, thruster4, thruster5, thruster6]
+
+    thruster_forces.write sample 
+
+    data = assert_has_one_new_sample body_efforts, 1
+
+    assert (data.linear[0] - 60).abs < 0.001, "wrong expected surge value"
+    assert (data.linear[1] - 0.0).abs < 0.001, "wrong expected sway value"
+    assert (data.linear[2] + 100).abs < 0.001, "wrong expected heave value"
+    assert (data.angular[2] - 0.0).abs < 0.001, "wrong expected yaw value"
+  end
+
+  it 'testing thruster sway force values' do
+
+    thruster_force_2_body_effort.apply_conf_file("auv_control::ThrusterForce2BodyEffort.yml")
+
+    thruster_force_2_body_effort.configure  
+    thruster_force_2_body_effort.start  
+
+    sample = thruster_force_2_body_effort.thruster_forces.new_sample
+      
+    thruster1 = Types::Base::JointState.new
+    thruster2 = Types::Base::JointState.new
+    thruster3 = Types::Base::JointState.new
+    thruster4 = Types::Base::JointState.new
+    thruster5 = Types::Base::JointState.new
+    thruster6 = Types::Base::JointState.new
+    thruster1.effort = 0
+    thruster2.effort = 0
+    thruster3.effort = 25
+    thruster4.effort = 32
+    thruster5.effort = 0
+    thruster6.effort = 0
+    
+    sample.elements = [thruster1, thruster2, thruster3, thruster4, thruster5, thruster6]
+
+    thruster_forces.write sample 
+
+    data = assert_has_one_new_sample body_efforts, 1
+
+    assert (data.linear[0] - 0.0).abs < 0.001, "wrong expected surge value"
+    assert (data.linear[1] + 57).abs < 0.001, "wrong expected sway value"
+    assert (data.linear[2] + 0.0).abs < 0.001, "wrong expected heave value"
+    assert (data.angular[2] - 15.615).abs < 0.001, "wrong expected yaw value"
+  end
+
+end
+

--- a/test/test_thruster_force_2_body_effort.rb
+++ b/test/test_thruster_force_2_body_effort.rb
@@ -38,10 +38,10 @@ describe 'auv_control::ThrusterForce2BodyEffort configuration' do
 
     data = assert_has_one_new_sample body_efforts, 1
 
-    assert (data.linear[0] - 60).abs < 0.001, "wrong expected surge value"
-    assert (data.linear[1] - 0.0).abs < 0.001, "wrong expected sway value"
-    assert (data.linear[2] + 100).abs < 0.001, "wrong expected heave value"
-    assert (data.angular[2] - 0.0).abs < 0.001, "wrong expected yaw value"
+    assert_in_delta data.linear[0], 60, 0.001, "wrong expected value for surge (x)"
+    assert_in_delta data.linear[1], 0, 0.001, "wrong expected value for sway (y)"
+    assert_in_delta data.linear[2], -100, 0.001, "wrong expected value for heave (z)"
+    assert_in_delta data.angular[2], 0, 0.001, "wrong expected value for yaw"
   end
 
   it 'testing thruster sway force values' do
@@ -52,7 +52,7 @@ describe 'auv_control::ThrusterForce2BodyEffort configuration' do
     thruster_force_2_body_effort.start  
 
     sample = thruster_force_2_body_effort.thruster_forces.new_sample
-      
+
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster3 = Types::Base::JointState.new
@@ -65,17 +65,17 @@ describe 'auv_control::ThrusterForce2BodyEffort configuration' do
     thruster4.effort = 32
     thruster5.effort = 0
     thruster6.effort = 0
-    
+
     sample.elements = [thruster1, thruster2, thruster3, thruster4, thruster5, thruster6]
 
     thruster_forces.write sample 
 
     data = assert_has_one_new_sample body_efforts, 1
 
-    assert (data.linear[0] - 0.0).abs < 0.001, "wrong expected surge value"
-    assert (data.linear[1] + 57).abs < 0.001, "wrong expected sway value"
-    assert (data.linear[2] + 0.0).abs < 0.001, "wrong expected heave value"
-    assert (data.angular[2] - 15.615).abs < 0.001, "wrong expected yaw value"
+    assert_in_delta data.linear[0], 0, 0.001, "wrong expected value for surge (x)"
+    assert_in_delta data.linear[1], -57, 0.001, "wrong expected value for sway (y)"
+    assert_in_delta data.linear[2], 0, 0.001, "wrong expected value for heave (z)"
+    assert_in_delta data.angular[2], 15.615, 0.001, "wrong expected value for yaw"
   end
 
 end

--- a/test/test_thruster_input.rb
+++ b/test/test_thruster_input.rb
@@ -16,7 +16,7 @@ describe 'auv_control::ThrustersInput configuration' do
     aux = thrusters_input.thruster_coeff_pos
     aux[0] = -8
     thrusters_input.thruster_coeff_pos = aux
-      
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
@@ -27,71 +27,75 @@ describe 'auv_control::ThrustersInput configuration' do
     aux = thrusters_input.thruster_coeff_neg
     aux[0] = -8
     thrusters_input.thruster_coeff_neg = aux
-      
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'wrong control_modes size' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'control_mode_3_raw'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'control_mode_3_raw'], true)
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'wrong thruster_coeff_pos size' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'thruster_coeff_pos_size_3'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'thruster_coeff_pos_size_3'], true)
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'automatically setting control_modes' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     aux = thrusters_input.control_modes
     aux.clear
     thrusters_input.control_modes = aux 
-      
+
     thrusters_input.configure
   end
 
   it 'pos and neg coefficients have different sizes' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'thruster_coeff_pos_size_3'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'thruster_coeff_pos_size_3'], true)
+
     aux = thrusters_input.control_modes
     aux.clear
     thrusters_input.control_modes = aux 
-      
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'control modes set to EFFORT' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'control_modes_effort'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'control_modes_effort'], true)
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'control mode equals to RAW but no thruster voltage was set' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     thrusters_input.thruster_voltage = 0
-    
+
     assert_raises(Orocos::StateTransitionFailed) { thrusters_input.configure }
   end
 
   it 'wrong number of thrusters input' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     thrusters_input.configure  
     thrusters_input.start  
-      
+
     sample = thrusters_input.cmd_in.new_sample
-    
+
     # 3 thrusters inputs were sent and 2 are expected
     thruster = Types::Base::JointState.new
     thruster.effort = 3
@@ -99,36 +103,35 @@ describe 'auv_control::ThrustersInput configuration' do
     cmd_in.write sample 
 
     assert_state_change(thrusters_input) { |s| s == :UNEXPECTED_THRUSTER_INPUT } 
-        
   end
   
   it 'thruster input not set' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     thrusters_input.configure  
     thrusters_input.start  
 
     sample = thrusters_input.cmd_in.new_sample
-      
+
     # the effort field was not set
     thruster = Types::Base::JointState.new
     sample.elements = [thruster, thruster]
     cmd_in.write sample 
 
     assert_state_change(thrusters_input) { |s| s == :UNSET_THRUSTER_INPUT } 
-        
   end
   
   it 'testing positive speed calculated value' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'control_modes_speed'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'control_modes_speed'], true)
+
     thrusters_input.configure  
     thrusters_input.start  
 
     sample = thrusters_input.cmd_in.new_sample
-      
+
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.effort = 37
@@ -137,21 +140,23 @@ describe 'auv_control::ThrustersInput configuration' do
     cmd_in.write sample 
 
     data = assert_has_one_new_sample cmd_out, 1
-    
-    assert (data.elements[0].speed - 1.9235).abs < 0.001
-    assert (data.elements[1].speed - 2.07364).abs < 0.001
-        
+
+    assert_in_delta data.elements[0].speed, 1.9235, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].speed, 2.07364, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing negative speed calculated value' do
 
-    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",['default', 'control_modes_speed'], true)
-    
+    thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml",
+        ['default', 'control_modes_speed'], true)
+
     thrusters_input.configure  
     thrusters_input.start  
 
     sample = thrusters_input.cmd_in.new_sample
-      
+
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.effort = -15
@@ -160,21 +165,22 @@ describe 'auv_control::ThrustersInput configuration' do
     cmd_in.write sample 
 
     data = assert_has_one_new_sample cmd_out, 1
-    
-    assert (data.elements[0].speed + 1.3693).abs < 0.001
-    assert (data.elements[1].speed + 0.9354).abs < 0.001
-        
+
+    assert_in_delta data.elements[0].speed, -1.3693, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].speed, -0.9354, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing positive raw calculated value' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     thrusters_input.configure  
     thrusters_input.start  
 
     sample = thrusters_input.cmd_in.new_sample
-      
+
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.effort = 17
@@ -183,20 +189,22 @@ describe 'auv_control::ThrustersInput configuration' do
     cmd_in.write sample 
 
     data = assert_has_one_new_sample cmd_out, 1
-    
-    assert (data.elements[0].raw - 0.0686).abs < 0.001
-    assert (data.elements[1].raw - 0.0288).abs < 0.001
+
+    assert_in_delta data.elements[0].raw, 0.0686, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].raw, 0.0288, 0.001,
+        "wrong expected value for thruster 2"
   end
 
   it 'testing negative raw calculated value' do
 
     thrusters_input.apply_conf_file("auv_control::ThrustersInput.yml")
-    
+
     thrusters_input.configure  
     thrusters_input.start  
 
     sample = thrusters_input.cmd_in.new_sample
-      
+
     thruster1 = Types::Base::JointState.new
     thruster2 = Types::Base::JointState.new
     thruster1.effort = -49
@@ -205,9 +213,11 @@ describe 'auv_control::ThrustersInput configuration' do
     cmd_in.write sample 
 
     data = assert_has_one_new_sample cmd_out, 1
-    
-    assert (data.elements[0].raw + 0.1302).abs < 0.001
-    assert (data.elements[1].raw + 0.1036).abs < 0.001
+
+    assert_in_delta data.elements[0].raw, -0.1302, 0.001,
+        "wrong expected value for thruster 1"
+    assert_in_delta data.elements[1].raw, -0.1036, 0.001,
+        "wrong expected value for thruster 2"
   end
 
 end


### PR DESCRIPTION
I've created two new tasks:
- ThrusterFeedback: which converts the thruster rotation feedback to thruster force domain
- ThrusterForce2BodyEffort: which converts the thruster forces to the body effort domain

The ThrusterFeedback task gets the RPM or PWM feedback provided by the thruster and calculates the generated force. It does the opposite of the ThrustesInput task, where the desired thruster force is converted to the necessary thruster command in terms of RPM or PWM.

I have subclassed the ThrusterFeedback task from the ThrustersInput task, but I created new in/out puts, only for matters of consistency with its real purpose (it doesn't receive nor output commands).

The ThrusterForce2BodyEffort task follows the previous task, and it will deliver efforts in the body frame domain.
