### PR TITLE
Go into error state if reference pose samples are too old

### DIFF
--- a/tasks/AlignedToBody.hpp
+++ b/tasks/AlignedToBody.hpp
@@ -4,6 +4,7 @@
 #define AUV_CONTROL_ALIGNEDTOBODY_TASK_HPP
 
 #include "auv_control/AlignedToBodyBase.hpp"
+#include <base/Timeout.hpp>
 
 namespace auv_control {
 
@@ -27,6 +28,7 @@ frame as input and outputs the same commands, but expressed in the body frame.
 	friend class AlignedToBodyBase;
     protected:
         base::samples::RigidBodyState orientation_sample;
+        base::Timeout new_orientation_samples_timeout;
         bool on_init;
         bool calcOutput();
 

--- a/tasks/OptimalHeadingController.hpp
+++ b/tasks/OptimalHeadingController.hpp
@@ -4,6 +4,7 @@
 #define AUV_CONTROL_OPTIMALHEADINGCONTROLLER_TASK_HPP
 
 #include "auv_control/OptimalHeadingControllerBase.hpp"
+#include <base/Timeout.hpp>
 
 namespace auv_control {
 
@@ -30,6 +31,7 @@ Frame.
     protected:
 
         base::samples::RigidBodyState orientation_sample;
+        base::Timeout new_orientation_samples_timeout;
         void keep();
         bool calcOutput();
 

--- a/tasks/PIDController.hpp
+++ b/tasks/PIDController.hpp
@@ -4,6 +4,7 @@
 #define AUV_CONTROL_PIDCONTROLLER_TASK_HPP
 
 #include "auv_control/PIDControllerBase.hpp"
+#include <base/Timeout.hpp>
 
 namespace auv_control {
 
@@ -28,6 +29,8 @@ world or aligned frames, and outputs "whatever" in the same frame
     protected:
         bool on_init;
         bool isPoseSampleValid();
+
+        base::Timeout new_pose_samples_timeout;
 
 
     public:

--- a/tasks/WorldToAligned.hpp
+++ b/tasks/WorldToAligned.hpp
@@ -6,6 +6,7 @@
 #include "auv_control/WorldToAlignedBase.hpp"
 #include <math.h>
 #include <float.h>
+#include <base/Timeout.hpp>
 
 namespace auv_control {
 
@@ -15,6 +16,7 @@ namespace auv_control {
     protected:
         base::samples::RigidBodyState currentPose;
         bool on_init;
+        base::Timeout new_pose_samples_timeout;
 
         void keepPosition();
         bool calcOutput();
@@ -26,6 +28,8 @@ namespace auv_control {
         WorldToAligned(std::string const& name, RTT::ExecutionEngine* engine);
 
 	    ~WorldToAligned();
+
+        bool configureHook();
 
         bool startHook();
 


### PR DESCRIPTION
Right now the components will continue to control even if no new pose samples arrive.
To recover from the error hook new pose samples have to arrive.
