### PR TITLE
Providing one cmd_out per timestamp. 

### DIFF
--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -28,7 +28,26 @@ namespace auv_control{
         PIDState linear[3];
         PIDState angular[3];
     };
-}    
+
+    enum CommandStatus
+    {
+        NEW_COMMAND,
+        OLD_COMMAND,
+        NO_COMMAND,
+        INVALID_COMMAND,
+    };
+
+    struct LinearAngular6DCommandStatus
+    {
+        base::LinearAngular6DCommand command;
+        CommandStatus status;
+
+        LinearAngular6DCommandStatus(){
+            command = base::LinearAngular6DCommand();
+            status = INVALID_COMMAND;
+        }
+    };
+}
 
 namespace base{
     struct LinearAngular6DWaypoint{

--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -35,17 +35,6 @@ namespace auv_control{
         motor_controller::PID linear[3];
         motor_controller::PID angular[3];
     };
-
-    struct LinearAngular6DCommandStatus
-    {
-        base::LinearAngular6DCommand command;
-        RTT::FlowStatus status;
-
-        LinearAngular6DCommandStatus(){
-            command = base::LinearAngular6DCommand();
-            status = RTT::NoData;
-        }
-    };
 }
 
 namespace base{

--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -7,6 +7,7 @@
 #include <base/Eigen.hpp>
 #include <base/Float.hpp>
 #include <base/commands/LinearAngular6DCommand.hpp>
+#include <rtt/FlowStatus.hpp>
 
 namespace auv_control{
     struct ExpectedInputs{
@@ -35,22 +36,14 @@ namespace auv_control{
         motor_controller::PID angular[3];
     };
 
-    enum CommandStatus
-    {
-        NEW_COMMAND,
-        OLD_COMMAND,
-        NO_COMMAND,
-        INVALID_COMMAND,
-    };
-
     struct LinearAngular6DCommandStatus
     {
         base::LinearAngular6DCommand command;
-        CommandStatus status;
+        RTT::FlowStatus status;
 
         LinearAngular6DCommandStatus(){
             command = base::LinearAngular6DCommand();
-            status = INVALID_COMMAND;
+            status = RTT::NoData;
         }
     };
 }

--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -27,6 +27,12 @@ namespace auv_control{
     struct LinearAngular6DPIDState{
         PIDState linear[3];
         PIDState angular[3];
+        base::Time time;
+    };
+
+    struct LinearAngular6DPID{
+        motor_controller::PID linear[3];
+        motor_controller::PID angular[3];
     };
 
     enum CommandStatus

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -142,6 +142,10 @@ task_context "WorldToAligned" do
     # given as input
     input_port 'pose_samples', 'base::samples::RigidBodyState'
 
+    # This property defines the timeout for the pose_samples input port in seconds.
+    # 0 means that the timeout would be ignored.
+    property "timeout_pose", "double", 1
+
     # The output command.
     output_port 'cmd_out', 'base::LinearAngular6DCommand'
 
@@ -159,9 +163,9 @@ task_context "AlignedToBody" do
     # Only the orientation is being used (to be more precise, only the pitch and
     # roll angles)
     input_port 'orientation_samples', 'base::samples::RigidBodyState'
-    
-    # This property defines the timeout for the cmd_in input port in seconds. 0
-    # means that the timeout would be ignored.
+
+    # This property defines the timeout for the orientation_samples input port in seconds.
+    # 0 means that the timeout would be ignored.
     property "timeout_orientation", "double", 1
 
     # The output command. It is expressed in the body frame, and is of the same

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -32,10 +32,10 @@ task_context "Base" do
     # This port is statically defined for simplicity reasons, additional ports
     # can be created using the addCommandInput operation
     input_port("cmd_in", "/base/LinearAngular6DCommand")
-    
-    # This property defines the timeout for the cmd_in input port in seconds. 0
-    # means that the timeout would be ignored.
-    property "timeout_in", "double", 1
+
+    # This property defines the timeout for the cmd_in input port. 0
+    # means that the timeout would be ignored. Default is 1 second.
+    property "timeout_in", "/base/Time"
 
     # When used in a cascade, this input port can be used to feed the output of
     # the controllers before.
@@ -45,11 +45,11 @@ task_context "Base" do
     # This port is statically defined for simplicity reasons, additional ports
     # can be created using the addCommandInput operation
     input_port('cmd_cascade', '/base/LinearAngular6DCommand')
-    
-    # This property defines the timeout for the cascade input port in seconds. 0
-    # means that the timeout would be ignored.
-    property "timeout_cascade", "double", 1
-   
+
+    # This property defines the timeout for the cascade input port. 0
+    # means that the timeout would be ignored. Default is 1 second.
+    property "timeout_cascade", "/base/Time"
+
     #This property defines the safty behavior ath the merging of the input-ports.
     #If the property is on true (default) the merged command need to be like in
     #the expected_inputs property defined. Else the expected_inputs are ignored 
@@ -62,7 +62,7 @@ task_context "Base" do
     # already exists
     operation("addCommandInput").
         argument("name", "string").
-        argument("timeout", "double").
+        argument("timeout", "/base/Time").
         returns('bool')
     dynamic_input_port(/cmd_\w+/, "/base/LinearAngular6DCommand")
 

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -107,11 +107,9 @@ task_context 'BasePIDController' do
 
     # The states of the pid-controllers
     output_port 'pid_state', '/auv_control/LinearAngular6DPIDState'
-    
-    error_states :WAIT_FOR_POSE_SAMPLE
-    
-    runtime_states :UNSURE_POSE_SAMPLE
-    exception_states :POSE_SAMPLE_INVALID
+
+    runtime_states :UNSURE_POSE_SAMPLE, :WAIT_FOR_POSE_SAMPLE
+    exception_states :POSE_SAMPLE_INVALID, :POSE_TIMEOUT
 end
 
 # Controller that takes either positions or velocities, expressed in either the

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -67,7 +67,7 @@ task_context "Base" do
     dynamic_input_port(/cmd_\w+/, "base::LinearAngular6DCommand")    
 
     runtime_states :CONTROLLING, :CONTROLLING_UNSAFE
-    error_states :INPUT_MISSING, :INPUT_COLLIDING, :INPUT_UNEXPECTED, :TIMEOUT, :WAIT_FOR_CONNECTED_INPUT_PORT, :WAIT_FOR_INPUT 
+    error_states :INPUT_MISSING, :INPUT_COLLIDING, :INPUT_UNEXPECTED, :TIMEOUT, :WAIT_FOR_CONNECTED_INPUT_PORT, :WAIT_FOR_INPUT, :ERROR_CALCOUTPUT
 
     # Deployed with a 10ms period by default
     periodic 0.01

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -67,7 +67,7 @@ task_context "Base" do
     dynamic_input_port(/cmd_\w+/, "base::LinearAngular6DCommand")    
 
     runtime_states :CONTROLLING, :CONTROLLING_UNSAFE
-    error_states :INPUT_MISSING, :INPUT_COLLIDING, :INPUT_UNEXPECTED, :TIMEOUT, :WAIT_FOR_CONNECTED_INPUT_PORT, :WAIT_FOR_INPUT, :ERROR_CALCOUTPUT
+    error_states :INPUT_MISSING, :INPUT_COLLIDING, :INPUT_UNEXPECTED, :TIMEOUT, :WAIT_FOR_CONNECTED_INPUT_PORT, :WAIT_FOR_INPUT
 
     # Deployed with a 10ms period by default
     periodic 0.01
@@ -96,9 +96,9 @@ task_context 'BasePIDController' do
     # Under this Value the axis are not controled. Output is 0.
     property "variance_threshold", "double"
 
-    # This property defines the timeout for the pose_samples input port in seconds.
-    # 0 means that the timeout would be ignored.
-    property "timeout_pose", "double", 1
+    # This property defines the timeout for the pose_samples input port.
+    # 0 means that the timeout would be ignored. Default is 1 second
+    property "timeout_pose", "base::Time"
 
     # The system state. Only the parts of the state that are controlled needs to
     # be available (i.e. if the command involves only orientation, only the
@@ -146,9 +146,9 @@ task_context "WorldToAligned" do
     # given as input
     input_port 'pose_samples', 'base::samples::RigidBodyState'
 
-    # This property defines the timeout for the pose_samples input port in seconds.
-    # 0 means that the timeout would be ignored.
-    property "timeout_pose", "double", 1
+    # This property defines the timeout for the pose_samples input port.
+    # 0 means that the timeout would be ignored. Default is 1 second
+    property "timeout_pose", "base::Time"
 
     # The output command.
     output_port 'cmd_out', 'base::LinearAngular6DCommand'
@@ -168,9 +168,9 @@ task_context "AlignedToBody" do
     # roll angles)
     input_port 'orientation_samples', 'base::samples::RigidBodyState'
 
-    # This property defines the timeout for the orientation_samples input port in seconds.
-    # 0 means that the timeout would be ignored.
-    property "timeout_orientation", "double", 1
+    # This property defines the timeout for the orientation_samples input port.
+    # 0 means that the timeout would be ignored. Default is 1 second
+    property "timeout_orientation", "base::Time"
 
     # The output command. It is expressed in the body frame, and is of the same
     # nature than the input (efforts if the inputs are efforts, velocities if

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -17,7 +17,7 @@ task_context "Base" do
 
     # This property defines which parts of the command input is expected to be
     # set once we merged all the declared input ports. 
-    property("expected_inputs", "auv_control::ExpectedInputs").
+    property("expected_inputs", "/auv_control/ExpectedInputs").
         dynamic
     
     # If true, the component will send a zero command before getting into an
@@ -31,7 +31,7 @@ task_context "Base" do
     # 
     # This port is statically defined for simplicity reasons, additional ports
     # can be created using the addCommandInput operation
-    input_port("cmd_in", "base::LinearAngular6DCommand")
+    input_port("cmd_in", "/base/LinearAngular6DCommand")
     
     # This property defines the timeout for the cmd_in input port in seconds. 0
     # means that the timeout would be ignored.
@@ -44,7 +44,7 @@ task_context "Base" do
     #
     # This port is statically defined for simplicity reasons, additional ports
     # can be created using the addCommandInput operation
-    input_port('cmd_cascade', 'base::LinearAngular6DCommand')
+    input_port('cmd_cascade', '/base/LinearAngular6DCommand')
     
     # This property defines the timeout for the cascade input port in seconds. 0
     # means that the timeout would be ignored.
@@ -64,7 +64,7 @@ task_context "Base" do
         argument("name", "string").
         argument("timeout", "double").
         returns('bool')
-    dynamic_input_port(/cmd_\w+/, "base::LinearAngular6DCommand")    
+    dynamic_input_port(/cmd_\w+/, "/base/LinearAngular6DCommand")
 
     runtime_states :CONTROLLING, :CONTROLLING_UNSAFE
     error_states :INPUT_MISSING, :INPUT_COLLIDING, :INPUT_UNEXPECTED, :TIMEOUT, :WAIT_FOR_CONNECTED_INPUT_PORT, :WAIT_FOR_INPUT
@@ -80,11 +80,11 @@ task_context 'BasePIDController' do
     subclasses "Base"
 
     # Ideal Settings for the PID controllers
-    property("pid_settings", "base::LinearAngular6DPIDSettings").
+    property("pid_settings", "/base/LinearAngular6DPIDSettings").
         dynamic
     
     # Parallel Settings for the PID controllers
-    property("parallel_pid_settings", "base::LinearAngular6DParallelPIDSettings").
+    property("parallel_pid_settings", "/base/LinearAngular6DParallelPIDSettings").
         dynamic
 
     # Use the Ideal (false) or Parallel PID-Settings 
@@ -98,16 +98,16 @@ task_context 'BasePIDController' do
 
     # This property defines the timeout for the pose_samples input port.
     # 0 means that the timeout would be ignored. Default is 1 second
-    property "timeout_pose", "base::Time"
+    property "timeout_pose", "/base/Time"
 
     # The system state. Only the parts of the state that are controlled needs to
     # be available (i.e. if the command involves only orientation, only the
     # orientation part is really needed)
-    input_port 'pose_samples', 'base::samples::RigidBodyState'
+    input_port 'pose_samples', '/base/samples/RigidBodyState'
 
     # The output command. It is a velocity command expressed in the aligned
     # frame.
-    output_port 'cmd_out', 'base::LinearAngular6DCommand'
+    output_port 'cmd_out', '/base/LinearAngular6DCommand'
 
     # The states of the pid-controllers
     output_port 'pid_state', '/auv_control/LinearAngular6DPIDState'
@@ -144,14 +144,14 @@ task_context "WorldToAligned" do
 
     # The system state. What is required depends on which parts of the state are
     # given as input
-    input_port 'pose_samples', 'base::samples::RigidBodyState'
+    input_port 'pose_samples', '/base/samples/RigidBodyState'
 
     # This property defines the timeout for the pose_samples input port.
     # 0 means that the timeout would be ignored. Default is 1 second
-    property "timeout_pose", "base::Time"
+    property "timeout_pose", "/base/Time"
 
     # The output command.
-    output_port 'cmd_out', 'base::LinearAngular6DCommand'
+    output_port 'cmd_out', '/base/LinearAngular6DCommand'
 
     runtime_states :WAIT_FOR_POSE_SAMPLE
     exception_states :POSE_SAMPLE_INVALID, :POSE_TIMEOUT
@@ -166,16 +166,16 @@ task_context "AlignedToBody" do
     #
     # Only the orientation is being used (to be more precise, only the pitch and
     # roll angles)
-    input_port 'orientation_samples', 'base::samples::RigidBodyState'
+    input_port 'orientation_samples', '/base/samples/RigidBodyState'
 
     # This property defines the timeout for the orientation_samples input port.
     # 0 means that the timeout would be ignored. Default is 1 second
-    property "timeout_orientation", "base::Time"
+    property "timeout_orientation", "/base/Time"
 
     # The output command. It is expressed in the body frame, and is of the same
     # nature than the input (efforts if the inputs are efforts, velocities if
     # the inputs are velocities)
-    output_port 'cmd_out', 'base::LinearAngular6DCommand'
+    output_port 'cmd_out', '/base/LinearAngular6DCommand'
 
     runtime_states :WAIT_FOR_ORIENTATION_SAMPLE
     exception_states :ORIENTATION_SAMPLE_INVALID, :ORIENTATION_TIMEOUT
@@ -194,30 +194,30 @@ task_context "AccelerationController" do
     # Matrix with size of 6 * n. n means the count of thrusters that are used.
     # The rows 0 to 2 of the matrix are the linear axis. The lines 3 to 5 of the
     # matrix are the angular axis.
-    property "matrix", "base::MatrixXd"
+    property "matrix", "/base/MatrixXd"
     
     # Weights that indicate which thrusters should be prioritized in
     # cases where multiple solutions are possible. The thrusters with lower
     # weights will be prioritized. The property size should be equal to the number of
     # thrusters and it must have only positive numbers. If there's no preference
     # between the thrusters, just assign the same weight to all of them.
-    property "thrusters_weights", "base::VectorXd"
+    property "thrusters_weights", "/base/VectorXd"
 
     # Names of the thrusters
     #
     # Leave empty to use no names
-    property "names", "std::vector<std::string>"  
+    property "names", "/std/vector</std/string>"
 
     # Limits of the thrusters
     #
     # Leave empty if you don't want to limit anything (is that really a good
     # idea ?)
-    property "limits", "base::JointLimits"
+    property "limits", "/base/JointLimits"
 
     # Lists which command parameter are being controlled on a per-joint basis.
     #
     # If left empty, uses RAW by default
-    property "control_modes", "std::vector<base::JointState::MODE>"
+    property "control_modes", "/std/vector</base/JointState/MODE>"
     
     # TRUE: allows the SVD solution for calculating the thrusters commands 
     #       similarly to pseudo-inverse solution.
@@ -226,7 +226,7 @@ task_context "AccelerationController" do
     property "svd_calculation", "bool", true
     
     # Generated motor commands
-    output_port "cmd_out", "base::commands::Joints"
+    output_port "cmd_out", "/base/commands/Joints"
 
     # The expected generated effort (as opposed to the input effort)
     output_port "expected_effort", "/base/LinearAngular6DCommand"
@@ -240,7 +240,7 @@ task_context "ConstantCommand" do
     property 'cmd', '/base/LinearAngular6DCommand'
 
     # The output command.
-    output_port 'cmd_out', 'base::LinearAngular6DCommand'
+    output_port 'cmd_out', '/base/LinearAngular6DCommand'
 
     periodic(0.01)
 end
@@ -249,8 +249,8 @@ end
 task_context "ConstantCommandGroundFollower" do 
     subclasses "ConstantCommand"
 
-    input_port "altimeter", "base::samples::RigidBodyState"
-    input_port "depth", "base::samples::RigidBodyState"
+    input_port "altimeter", "/base/samples/RigidBodyState"
+    input_port "depth", "/base/samples/RigidBodyState"
     output_port "floor_position", "double"
     
     runtime_states(:NO_DEPTH_READING, :NO_ALTIMETER_READING)
@@ -264,18 +264,18 @@ task_context "WaypointNavigator" do
 
     # The trajectory to follow, expressed as a set of waypoints in the world
     # frame
-    input_port "trajectory", "std::vector<base::LinearAngular6DWaypoint>"
+    input_port "trajectory", "/std/vector</base/LinearAngular6DWaypoint>"
     
     # The current system pose
-    input_port "pose_sample", "base::samples::RigidBodyState"
+    input_port "pose_sample", "/base/samples/RigidBodyState"
 
     # The output command, as a pose in world frame that can be used by the
     # auv_control controllers
-    output_port "cmd_out", "base::LinearAngular6DCommand"
+    output_port "cmd_out", "/base/LinearAngular6DCommand"
    
     # Shows error between current and desired waypoint for debuging,
     # current waypoint is navigated by this controller and remaining waypoints zo follow 
-    output_port("waypoint_info", "base::LinearAngular6DWaypointInfo")
+    output_port("waypoint_info", "/base/LinearAngular6DWaypointInfo")
 
     runtime_states :WAIT_FOR_WAYPOINTS, :KEEP_WAYPOINT,
         :FOLLOWING_WAYPOINTS, :POSE_SAMPLE_MISSING
@@ -316,10 +316,10 @@ task_context "OptimalHeadingController" do
     
     # The system state. What is required depends on which parts of the state are
     # given as input
-    input_port 'orientation_samples', 'base::samples::RigidBodyState'
+    input_port 'orientation_samples', '/base/samples/RigidBodyState'
     
     # The output command.
-    output_port 'cmd_out', 'base::LinearAngular6DCommand'
+    output_port 'cmd_out', '/base/LinearAngular6DCommand'
 
     error_states :WAIT_FOR_ORIENTATION_SAMPLE
 end
@@ -337,20 +337,20 @@ task_context "ThrustersBase" do
     # Convert thruster signal into forces, in negative direction or CCW.
     # Should have a size equal to the number of thrusters
     # Thruster[N] = Coeff * rotation * |rotation|
-    property "thruster_coeff_neg", "base::VectorXd"    
+    property "thruster_coeff_neg", "/base/VectorXd"
     
     # If left empty, uses RAW by default  
-    property "control_modes", "std::vector<base::JointState::MODE>" 
     
+    property "control_modes", "/std/vector</base/JointState/MODE>"
     # In case the control_modes is RAW (pwm), used to convert the signal into DC Voltage
     # Thruster[N] = Coeff * voltage * |voltage|  
     property "thruster_voltage", "double", 0  
 
     # The description about the ports are specified in ThrustersInput and
     # ThrustersFeedback tasks
-    input_port "cmd_in", "base::commands::Joints"
+    input_port "cmd_in", "/base/commands/Joints"
 
-    output_port "cmd_out", "base::commands::Joints"
+    output_port "cmd_out", "/base/commands/Joints"
 
     exception_states :UNSET_THRUSTER_INPUT, :UNEXPECTED_THRUSTER_INPUT 
                     
@@ -391,14 +391,14 @@ task_context "ThrusterForce2BodyEffort" do
     # Matrix with size of 6 * n. n means the count of thrusters that are used.
     # The rows 0 to 2 of the matrix are the linear axis. The lines 3 to 5 of the
     # matrix are the angular axis.
-    property "thruster_configuration_matrix", "base::MatrixXd"
+    property "thruster_configuration_matrix", "/base/MatrixXd"
 
     # Thruster individual forces
-    input_port "thruster_forces", "base::commands::Joints"
+    input_port "thruster_forces", "/base/commands/Joints"
 
     # Body efforts once the thruster configuration matrix is applied to the
     # thruster forces
-    output_port "body_efforts", "base::LinearAngular6DCommand"
+    output_port "body_efforts", "/base/LinearAngular6DCommand"
 
     exception_states :UNSET_THRUSTER_INPUT, :UNEXPECTED_THRUSTER_INPUT
 
@@ -413,8 +413,8 @@ task_context "CommandInjection" do
     property "cmd_injection_timeout", "double", 0.05
 
     # Non NaN values will be injected in the cascade input
-    input_port "cmd_injection", "base::LinearAngular6DCommand"
+    input_port "cmd_injection", "/base/LinearAngular6DCommand"
 
     # The output command
-    output_port "cmd_out", "base::LinearAngular6DCommand"
+    output_port "cmd_out", "/base/LinearAngular6DCommand"
 end

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -144,9 +144,9 @@ task_context "WorldToAligned" do
 
     # The output command.
     output_port 'cmd_out', 'base::LinearAngular6DCommand'
-    
-    error_states :WAIT_FOR_POSE_SAMPLE
-    exception_states :POSE_SAMPLE_INVALID
+
+    runtime_states :WAIT_FOR_POSE_SAMPLE
+    exception_states :POSE_SAMPLE_INVALID, :POSE_TIMEOUT
 end
 
 # Controller that takes either velocities or efforts expressed in the aligned
@@ -168,9 +168,9 @@ task_context "AlignedToBody" do
     # nature than the input (efforts if the inputs are efforts, velocities if
     # the inputs are velocities)
     output_port 'cmd_out', 'base::LinearAngular6DCommand'
-    
-    error_states :WAIT_FOR_ORIENTATION_SAMPLE
-    exception_states :ORIENTATION_SAMPLE_INVALID
+
+    runtime_states :WAIT_FOR_ORIENTATION_SAMPLE
+    exception_states :ORIENTATION_SAMPLE_INVALID, :ORIENTATION_TIMEOUT
 end
 
 # Generates thruster commands based on a thruster matrix and a force-torque

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -96,6 +96,10 @@ task_context 'BasePIDController' do
     # Under this Value the axis are not controled. Output is 0.
     property "variance_threshold", "double"
 
+    # This property defines the timeout for the pose_samples input port in seconds.
+    # 0 means that the timeout would be ignored.
+    property "timeout_pose", "double", 1
+
     # The system state. Only the parts of the state that are controlled needs to
     # be available (i.e. if the command involves only orientation, only the
     # orientation part is really needed)

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -108,7 +108,7 @@ task_context 'BasePIDController' do
     # The states of the pid-controllers
     output_port 'pid_state', '/auv_control/LinearAngular6DPIDState'
 
-    runtime_states :UNSURE_POSE_SAMPLE, :WAIT_FOR_POSE_SAMPLE
+    error_states :UNSURE_POSE_SAMPLE
     exception_states :POSE_SAMPLE_INVALID, :POSE_TIMEOUT
 end
 

--- a/tasks/AccelerationController.cpp
+++ b/tasks/AccelerationController.cpp
@@ -135,10 +135,10 @@ bool AccelerationController::startHook()
 
     return true;
 }
-bool AccelerationController::calcOutput()
+bool AccelerationController::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
 
-    inputVector << merged_command.linear, merged_command.angular;
+    inputVector << merged_command.command.linear, merged_command.command.angular;
     for (int i = 0; i < 6; ++i)
     {
         if (base::isUnset(inputVector(i)))
@@ -174,7 +174,7 @@ bool AccelerationController::calcOutput()
             }
         }
         jointCommand[i].setField(controlModes[i], cmdVector(i));
-        jointCommand.time = merged_command.time;
+        jointCommand.time = merged_command.command.time;
     }
     _cmd_out.write(jointCommand);
 

--- a/tasks/AccelerationController.hpp
+++ b/tasks/AccelerationController.hpp
@@ -23,7 +23,7 @@ namespace auv_control {
         std::vector<std::string> names;
         base::JointLimits limits;
 
-        bool calcOutput();
+        bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
 
     public:
         /** TaskContext constructor for AccelerationController

--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -45,10 +45,9 @@ bool AlignedToBody::startHook()
     return validateInputExpectations(expect.linear, "linear") &&
         validateInputExpectations(expect.angular, "angular");
 }
-bool AlignedToBody::calcOutput()
+bool AlignedToBody::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
- 
-    base::LinearAngular6DCommand output_command = merged_command;
+    base::LinearAngular6DCommand output_command = merged_command.command;
 
     double yaw = base::getYaw(orientation_sample.orientation);
     Eigen::Quaterniond orientation_pr =

--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -29,7 +29,7 @@ bool AlignedToBody::configureHook()
     if (! AlignedToBodyBase::configureHook())
         return false;
 
-    new_orientation_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_in.value()));
+    new_orientation_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_orientation.value()));
 
     return true;
 }

--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -7,11 +7,13 @@ using namespace auv_control;
 AlignedToBody::AlignedToBody(std::string const& name)
     : AlignedToBodyBase(name)
 {
+    _timeout_orientation.set(base::Time::fromSeconds(1));
 }
 
 AlignedToBody::AlignedToBody(std::string const& name, RTT::ExecutionEngine* engine)
     : AlignedToBodyBase(name, engine)
 {
+    _timeout_orientation.set(base::Time::fromSeconds(1));
 }
 
 AlignedToBody::~AlignedToBody()
@@ -29,7 +31,7 @@ bool AlignedToBody::configureHook()
     if (! AlignedToBodyBase::configureHook())
         return false;
 
-    new_orientation_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_orientation.value()));
+    new_orientation_samples_timeout = base::Timeout(_timeout_orientation.get());
 
     return true;
 }

--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -47,6 +47,11 @@ bool AlignedToBody::startHook()
 }
 bool AlignedToBody::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
+    // In case there is an OLD_COMMAND, it should not output the same cmd again,
+    // but no error occurred
+    if (merged_command.status == OLD_COMMAND)
+        return true;
+
     base::LinearAngular6DCommand output_command = merged_command.command;
 
     double yaw = base::getYaw(orientation_sample.orientation);

--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -47,9 +47,9 @@ bool AlignedToBody::startHook()
 }
 bool AlignedToBody::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
-    // In case there is an OLD_COMMAND, it should not output the same cmd again,
+    // In case there is an OldData, it should not output the same cmd again,
     // but no error occurred
-    if (merged_command.status == OLD_COMMAND)
+    if (merged_command.status == RTT::OldData)
         return true;
 
     base::LinearAngular6DCommand output_command = merged_command.command;

--- a/tasks/AlignedToBody.hpp
+++ b/tasks/AlignedToBody.hpp
@@ -30,7 +30,7 @@ frame as input and outputs the same commands, but expressed in the body frame.
         base::samples::RigidBodyState orientation_sample;
         base::Timeout new_orientation_samples_timeout;
         bool on_init;
-        bool calcOutput();
+        bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
 
     public:
         /** TaskContext constructor for AlignedToBody

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -160,6 +160,7 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
     // The command that is being merged. It is written to this->merged_command
     // only if everything has been validated
     bool has_at_least_one_new_command = false;
+    merged_command.status = RTT::NoData;
     for(unsigned int i = 0; i < connected_ports.size(); i++){
         base::LinearAngular6DCommand current_port;
         InputPortInfo& port_info = *connected_ports.at(i);
@@ -168,10 +169,7 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
         RTT::FlowStatus status = port->readNewest(current_port);
 
         if(status == RTT::NoData)
-        {
-            merged_command.status = NO_COMMAND;
             return WAIT_FOR_INPUT;
-        }
         else if(status == RTT::NewData)
         {   // Not all input is OldData
             has_at_least_one_new_command = true;
@@ -189,11 +187,11 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
         return TIMEOUT;
     if(_safe_mode.get() && !verifyMissingData(_expected_inputs.get(), merged_command.command))
         return INPUT_MISSING;
-    merged_command.command.time = newestCommandTime;
 
-    merged_command.status = NEW_COMMAND;
+    merged_command.command.time = newestCommandTime;
+    merged_command.status = RTT::NewData;
     if (!has_at_least_one_new_command)
-        merged_command.status = OLD_COMMAND;
+        merged_command.status = RTT::OldData;
     return CONTROLLING;
 }
 

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -262,7 +262,7 @@ Base::States Base::merge(auv_control::ExpectedInputs const& expected, base::Line
 bool Base::checkConnectedPorts(std::vector<Base::InputPortInfo> &input_ports, std::vector<Base::InputPortInfo*> &connected_input_ports)
 {   // Clear vector before assign connected ports
     if(!connected_input_ports.empty())
-        connected_input_ports.erase(connected_input_ports.begin(), connected_input_ports.end());
+        connected_input_ports.clear();
     for(unsigned int i = 0; i < input_ports.size(); i++)
     {
         if(input_ports.at(i).input_port->connected())

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -159,8 +159,7 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
 {
     // The command that is being merged. It is written to this->merged_command
     // only if everything has been validated
-    bool has_at_least_one_new_command = false;
-    merged_command.status = RTT::NoData;
+    merged_command.status = RTT::OldData;
     for(unsigned int i = 0; i < connected_ports.size(); i++){
         base::LinearAngular6DCommand current_port;
         InputPortInfo& port_info = *connected_ports.at(i);
@@ -171,8 +170,8 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
         if(status == RTT::NoData)
             return WAIT_FOR_INPUT;
         else if(status == RTT::NewData)
-        {   // Not all input is OldData
-            has_at_least_one_new_command = true;
+        {   // Has at least one new data
+            merged_command.status = RTT::NewData;
             port_info.last_sample_time = current_port.time;
             port_info.last_system_time = base::Time::now();
             if (newestCommandTime < current_port.time)
@@ -189,9 +188,6 @@ Base::States Base::gatherInputCommand(LinearAngular6DCommandStatus &merged_comma
         return INPUT_MISSING;
 
     merged_command.command.time = newestCommandTime;
-    merged_command.status = RTT::NewData;
-    if (!has_at_least_one_new_command)
-        merged_command.status = RTT::OldData;
     return CONTROLLING;
 }
 

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -7,11 +7,15 @@ using namespace auv_control;
 Base::Base(std::string const& name)
     : BaseBase(name)
 {
+    _timeout_in.set(base::Time::fromSeconds(1));
+    _timeout_cascade.set(base::Time::fromSeconds(1));
 }
 
 Base::Base(std::string const& name, RTT::ExecutionEngine* engine)
     : BaseBase(name, engine)
 {
+    _timeout_in.set(base::Time::fromSeconds(1));
+    _timeout_cascade.set(base::Time::fromSeconds(1));
 }
 
 Base::~Base()
@@ -131,7 +135,7 @@ Base::States Base::performOneLoop()
     return CONTROLLING_UNSAFE;
 }
 
-void Base::registerInput(std::string const& name, int timeout, InputPortType* input_port)
+void Base::registerInput(std::string const& name, base::Time timeout, InputPortType* input_port)
 {
     InputPortInfo info;
     info.name = name;
@@ -200,11 +204,11 @@ bool Base::verifyTimeout(const base::Time &newest_command)
     {
         if(input_ports[i].input_port->connected())
         {
-            double timeout = input_ports[i].timeout;
+            base::Time timeout = input_ports[i].timeout;
             base::Time port_time = input_ports[i].last_sample_time;
-            if (timeout != 0 && ((newest_command - port_time).toSeconds() > timeout))
+            if (timeout.toSeconds() != 0 && ((newest_command - port_time) > timeout))
                 return false;
-            if (timeout != 0 && ((base::Time::now() - input_ports[i].last_system_time).toSeconds() > timeout))
+            if (timeout.toSeconds() != 0 && ((base::Time::now() - input_ports[i].last_system_time) > timeout))
                 return false;
         }
     }
@@ -223,7 +227,7 @@ bool Base::verifyMissingData(const auv_control::ExpectedInputs &expected, const 
     return true;
 }
 
-bool Base::addCommandInput(std::string const & name, double timeout){
+bool Base::addCommandInput(std::string const & name, base::Time const & timeout){
     if (provides()->hasService("cmd_" + name))
         return false;
 

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -50,9 +50,9 @@ void Base::updateHook()
 {
     BaseBase::updateHook();
 
-    States stat = OneLoop();
+    States stat = performOneLoop();
     // Error in calcOutput, state transitions should be handle in derived class
-    if(stat == ERROR_CALCOUTPUT)
+    if(stat == RUNTIME_ERROR)
         return;
     // Check for local error in Base
     if(stat != CONTROLLING && stat != CONTROLLING_UNSAFE)
@@ -71,9 +71,9 @@ void Base::errorHook()
 {
     BaseBase::errorHook();
 
-    States stat = OneLoop();
+    States stat = performOneLoop();
     // Error in calcOutput, state transitions should be handle in derived class
-    if(stat == ERROR_CALCOUTPUT)
+    if(stat == RUNTIME_ERROR)
         return;
     // Return to Running state
     if(stat == CONTROLLING || stat == CONTROLLING_UNSAFE)
@@ -109,7 +109,7 @@ void Base::cleanupHook()
     }
 }
 
-Base::States Base::OneLoop()
+Base::States Base::performOneLoop()
 {
     std::vector<Base::InputPortInfo*> in_ports = checkConnectedPorts(input_ports);
     if(!in_ports.size())
@@ -122,7 +122,7 @@ Base::States Base::OneLoop()
         return state;
 
     if (!this->calcOutput(merging_command))
-        return ERROR_CALCOUTPUT;
+        return RUNTIME_ERROR;
 
     if (_safe_mode.get())
         return CONTROLLING;

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -24,7 +24,6 @@ namespace auv_control {
         };    
     
         std::vector<InputPortInfo> input_ports;
-        base::LinearAngular6DCommand merged_command;        
 
         void registerInput(std::string const& name, int timeout, InputPortType* input_port);
         InputPortType* deregisterInput(std::string const& name);
@@ -62,7 +61,7 @@ namespace auv_control {
          * @param connected_ports to be analyzed.
          * @return States of wich it should go
          */
-        States gatherInputCommand(LinearAngular6DCommandStatus &merging_command, std::vector<Base::InputPortInfo*> &connected_ports);
+        States gatherInputCommand(LinearAngular6DCommandStatus &merged_command, std::vector<Base::InputPortInfo*> &connected_ports);
 
         /** Creates a new input port called cmd_name of the type
          * LinearAngular6DCommand. Once defined, this input port will be merged
@@ -88,13 +87,8 @@ namespace auv_control {
          * @return bool. TRUE if there is NO state transition in derived class,
          *               FALSE otherwise.
          */
-        virtual bool calcOutput(const LinearAngular6DCommandStatus &merging_command);
+        virtual bool calcOutput(const LinearAngular6DCommandStatus &merging_command) = 0;
 
-        /** Computes the output based on the value stored in merged_command. It
-         * is called after merged_command has been updated
-         */ 
-        virtual bool calcOutput() = 0;
-        
     public:
         /** TaskContext constructor for Base
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -24,6 +24,7 @@ namespace auv_control {
         };    
     
         std::vector<InputPortInfo> input_ports;
+        std::vector<Base::InputPortInfo*> connected_input_ports;
 
         void registerInput(std::string const& name, int timeout, InputPortType* input_port);
         InputPortType* deregisterInput(std::string const& name);
@@ -49,10 +50,11 @@ namespace auv_control {
 
         /** Check for connected ports
          *
-         * @param in_ports: vector of input ports to be verified
-         * @return vector of address of connected ports
+         * @param input_ports: vector of input ports to be verified
+         * @param connected_input_ports: vector of address of connected input_ports to be assigned
+         * @return bool. TRUE if at least one port is connected, FALSE otherwise
          */
-        std::vector<Base::InputPortInfo*> checkConnectedPorts(std::vector<Base::InputPortInfo> &in_ports) const;
+        bool checkConnectedPorts(std::vector<Base::InputPortInfo> &input_ports, std::vector<Base::InputPortInfo*> &connected_input_ports);
 
         /** Gather input from connected input ports
          *

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -176,7 +176,7 @@ namespace auv_control {
          *
          * @return States which it should go.
          */
-        States OneLoop();
+        States performOneLoop();
     private:
         States merge(auv_control::ExpectedInputs const& expected, base::LinearAngular6DCommand const& current, base::LinearAngular6DCommand &merged);
 

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -24,7 +24,7 @@ namespace auv_control {
         typedef RTT::InputPort<base::LinearAngular6DCommand> InputPortType;
         struct InputPortInfo{
             std::string name;
-            double timeout;
+            base::Time timeout;
             base::Time last_sample_time;
             base::Time last_system_time;
             InputPortType *input_port;
@@ -35,7 +35,7 @@ namespace auv_control {
         std::vector<InputPortInfo> input_ports;
         std::vector<Base::InputPortInfo*> connected_input_ports;
 
-        void registerInput(std::string const& name, int timeout, InputPortType* input_port);
+        void registerInput(std::string const& name, base::Time timeout, InputPortType* input_port);
         InputPortType* deregisterInput(std::string const& name);
         base::Time newestCommandTime;
 
@@ -78,7 +78,7 @@ namespace auv_control {
          * into the merged_command command before the controller calculates the
          * corresponding output
          */
-        virtual bool addCommandInput(::std::string const & name, double timeout);
+        virtual bool addCommandInput(::std::string const & name, ::base::Time const & timeout);
 
         /** Send a "do not move" command to the next level
          *

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -8,6 +8,15 @@
 
 namespace auv_control {
 
+    struct LinearAngular6DCommandStatus{
+        base::LinearAngular6DCommand command;
+        RTT::FlowStatus status;
+        LinearAngular6DCommandStatus(){
+            command = base::LinearAngular6DCommand();
+            status = RTT::NoData;
+        }
+    };
+
     class Base : public BaseBase
     {
 	friend class BaseBase;
@@ -21,8 +30,8 @@ namespace auv_control {
             InputPortType *input_port;
             InputPortInfo()
                 :input_port(0){}
-        };    
-    
+        };
+
         std::vector<InputPortInfo> input_ports;
         std::vector<Base::InputPortInfo*> connected_input_ports;
 

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -58,8 +58,7 @@ namespace auv_control {
 
         /** Gather input from connected input ports
          *
-         * @param merging_command, where the commands will be safe
-         * @param cmd_status, Define the status of merging_command, NEW_COMMAND, OLD_COMMAND, NO_COMMAND or INVALID_COMMAND
+         * @param merged_command, where the commands will be safe all together with its RTT:FlowStatus
          * @param connected_ports to be analyzed.
          * @return States of wich it should go
          */
@@ -89,7 +88,7 @@ namespace auv_control {
          * @return bool. TRUE if there is NO state transition in derived class,
          *               FALSE otherwise.
          */
-        virtual bool calcOutput(const LinearAngular6DCommandStatus &merging_command) = 0;
+        virtual bool calcOutput(const LinearAngular6DCommandStatus &merged_command) = 0;
 
     public:
         /** TaskContext constructor for Base

--- a/tasks/BasePIDController.cpp
+++ b/tasks/BasePIDController.cpp
@@ -23,12 +23,12 @@ BasePIDController::~BasePIDController()
 
 bool BasePIDController::setParallel_pid_settings(::base::LinearAngular6DParallelPIDSettings const & value)
 {
-    if(use_parallel_pid_settings)
+    if(_use_parallel_pid_settings.get())
     {
         for (int i = 0; i < 3; ++i)
         {
-            mLinearPIDs[i].setParallelPIDSettings(value.linear[i]);
-            mAngularPIDs[i].setParallelPIDSettings(value.angular[i]);
+            mPIDs.linear[i].setParallelPIDSettings(value.linear[i]);
+            mPIDs.angular[i].setParallelPIDSettings(value.angular[i]);
         }
     }
     else return false;
@@ -37,16 +37,53 @@ bool BasePIDController::setParallel_pid_settings(::base::LinearAngular6DParallel
 
 bool BasePIDController::setPid_settings(::base::LinearAngular6DPIDSettings const & value)
 {
-    if(!use_parallel_pid_settings)
+    if(!_use_parallel_pid_settings.get())
     {
         for (int i = 0; i < 3; ++i)
         {
-            mLinearPIDs[i].setPIDSettings(value.linear[i]);
-            mAngularPIDs[i].setPIDSettings(value.angular[i]);
+            mPIDs.linear[i].setPIDSettings(value.linear[i]);
+            mPIDs.angular[i].setPIDSettings(value.angular[i]);
         }
     }
     else return false;
     return(BasePIDControllerBase::setPid_settings(value));
+}
+
+std::pair<base::LinearAngular6DCommand, LinearAngular6DPIDState> BasePIDController::calcPIDStateCommand(
+    const base::LinearAngular6DCommand &reference, const currentState &current_state, LinearAngular6DPID &pid)
+{
+    // We start by copying the reference so that we can simply ignore the unset
+    // values, but get the timestamp from the current_state
+    base::LinearAngular6DCommand command_out = reference;
+    command_out.time = current_state.time;
+    LinearAngular6DPIDState pid_state;
+    pid_state.time = current_state.time;
+
+    for (int i = 0; i < 3; ++i)
+    {   // Linear case
+        if (!base::isUnset(reference.linear(i)))
+        {
+            command_out.linear[i] =
+                pid.linear[i].update(current_state.linear(i),
+                                   reference.linear(i),
+                                   current_state.time.toSeconds());
+            pid_state.linear[i] = auv_control::PIDState(pid.linear[i].getState(), true);
+        }
+        else
+            pid_state.linear[i].active = false;
+        // Angular case
+        if (!base::isUnset(reference.angular(i)))
+        {
+            command_out.angular[i] =
+                pid.angular[i].update(current_state.angular(i),
+                                   reference.angular(i),
+                                   current_state.time.toSeconds());
+            pid_state.angular[i] = auv_control::PIDState(pid.angular[i].getState(), true);
+        }
+        else
+            pid_state.angular[i].active = false;
+    }
+    return std::make_pair(command_out, pid_state);
 }
 
 /// The following lines are template definitions for the various state machine
@@ -60,15 +97,14 @@ bool BasePIDController::configureHook()
 
     // set derivative mode
     motor_controller::DerivativeMode derivative_mode = motor_controller::Output;
-    if(_apply_derivative_to_error)
+    if(_apply_derivative_to_error.get())
         derivative_mode = motor_controller::Error;
     for (int i = 0; i < 3; ++i)
     {
-        mLinearPIDs[i].setDerivativeMode(derivative_mode);
-        mAngularPIDs[i].setDerivativeMode(derivative_mode);
+        mPIDs.linear[i].setDerivativeMode(derivative_mode);
+        mPIDs.angular[i].setDerivativeMode(derivative_mode);
     }
 
-    use_parallel_pid_settings = _use_parallel_pid_settings;
     setPid_settings(_pid_settings.get());
     setParallel_pid_settings(_parallel_pid_settings.get());
     return true;
@@ -89,8 +125,8 @@ void BasePIDController::errorHook()
     // reset the contollers since the control loop is interrupted
     for (unsigned i = 0; i < 3; ++i)
     {
-        mLinearPIDs[i].reset();
-        mAngularPIDs[i].reset();
+        mPIDs.linear[i].reset();
+        mPIDs.angular[i].reset();
     }
 
     BasePIDControllerBase::errorHook();
@@ -103,73 +139,44 @@ void BasePIDController::cleanupHook()
 {
     BasePIDControllerBase::cleanupHook();
 }
-bool BasePIDController::calcOutput()
+bool BasePIDController::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
-    // We start by copying merged_command so that we can simply ignore the unset
-    // values
-    base::LinearAngular6DCommand output_command = merged_command;
-    LinearAngular6DPIDState pid_state;
-    for (int i = 0; i < 3; ++i)
-    {
-        if (!base::isUnset(merged_command.linear(i)))
-        {
-            output_command.linear(i) =
-                mLinearPIDs[i].update(currentLinear(i),
-                                   merged_command.linear(i),
-                                   merged_command.time.toSeconds());
-            pid_state.linear[i] = auv_control::PIDState(mLinearPIDs[i].getState(), true);
-        }
-        else
-        {
-            pid_state.linear[i].active = false;
-        }
-        if (!base::isUnset(merged_command.angular(i)))
-        {
-            output_command.angular(i) =
-                mAngularPIDs[i].update(currentAngular(i),
-                                   merged_command.angular(i),
-                                   merged_command.time.toSeconds());
-            pid_state.angular[i] = auv_control::PIDState(mAngularPIDs[i].getState(), true);
-        }
-        else
-        {
-            pid_state.angular[i].active = false;
-        }
-    }
+    std::pair<base::LinearAngular6DCommand, LinearAngular6DPIDState> cmd_status;
+    // Compute the pair of output_command and pid_state and update mPIDs
+    cmd_status = calcPIDStateCommand(merged_command.command, mCurrentState, mPIDs);
+
+    base::LinearAngular6DCommand output_command = cmd_status.first;
 
     // Stop controling for axis with bad variance
-    bool unsure_pose = false; 
+    bool unsure_pose = false;
     for(unsigned i = 0; i < 3; i++){
-        if(currentLinearCov(i,i) > _variance_threshold.get()){
+        if(mCurrentCov.linear(i,i) > _variance_threshold.get()){
             output_command.linear(i) = 0;
             unsure_pose = true;
-            if(state() != UNSURE_POSE_SAMPLE){
-                state(UNSURE_POSE_SAMPLE);
-            }
         }
-        if(currentAngularCov(i,i) > _variance_threshold.get()){
+        if(mCurrentCov.angular(i,i) > _variance_threshold.get()){
             output_command.angular(i) = 0;
             unsure_pose = true;
-            if(state() != UNSURE_POSE_SAMPLE){
-                state(UNSURE_POSE_SAMPLE);
-            }
         }
     }
 
-    output_command.time = pose_sample.time;
-    _pid_state.write(pid_state);
+    _pid_state.write(cmd_status.second);
     _cmd_out.write(output_command);
-    
+
     if(unsure_pose){
+        if(state() != UNSURE_POSE_SAMPLE)
+            state(UNSURE_POSE_SAMPLE);
         return false;
     }
-    
     return true;
 }
 
+bool BasePIDController::calcOutput()
+{return true;}
+
 void BasePIDController::keepPosition(){
     base::LinearAngular6DCommand output_command;
-    output_command.time = pose_sample.time;
+    output_command.time = mCurrentState.time;
     if(!_nan_on_keep_position.get()){
         for(unsigned int i = 0; i < 3; i++){
             if(_expected_inputs.get().linear[i]){
@@ -182,4 +189,3 @@ void BasePIDController::keepPosition(){
     }
     _cmd_out.write(output_command);
 }
-

--- a/tasks/BasePIDController.cpp
+++ b/tasks/BasePIDController.cpp
@@ -156,6 +156,7 @@ bool BasePIDController::calcOutput()
         }
     }
 
+    output_command.time = pose_sample.time;
     _pid_state.write(pid_state);
     _cmd_out.write(output_command);
     

--- a/tasks/BasePIDController.cpp
+++ b/tasks/BasePIDController.cpp
@@ -171,9 +171,6 @@ bool BasePIDController::calcOutput(const LinearAngular6DCommandStatus &merged_co
     return true;
 }
 
-bool BasePIDController::calcOutput()
-{return true;}
-
 void BasePIDController::keepPosition(){
     base::LinearAngular6DCommand output_command;
     output_command.time = mCurrentState.time;

--- a/tasks/BasePIDController.hpp
+++ b/tasks/BasePIDController.hpp
@@ -54,7 +54,6 @@ generate commands
         LinearAngular6DPID mPIDs;
 
         bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
-        bool calcOutput();
         void keepPosition();
 
 

--- a/tasks/CommandInjection.cpp
+++ b/tasks/CommandInjection.cpp
@@ -18,9 +18,9 @@ CommandInjection::~CommandInjection()
 {
 }
 
-bool CommandInjection::calcOutput()
+bool CommandInjection::calcOutput(const LinearAngular6DCommandStatus &merged_command)
 {
-    base::LinearAngular6DCommand output_command = merged_command;
+    base::LinearAngular6DCommand output_command = merged_command.command;
 
     base::LinearAngular6DCommand cmd_injection;
     if(receiveCommandInjection(cmd_injection))

--- a/tasks/CommandInjection.hpp
+++ b/tasks/CommandInjection.hpp
@@ -27,7 +27,7 @@ namespace auv_control {
 	friend class CommandInjectionBase;
     protected:
         base::Time newest_injection_sample;
-        bool calcOutput();
+        bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
         bool receiveCommandInjection(base::LinearAngular6DCommand& cmd_injection);
 
     public:

--- a/tasks/OptimalHeadingController.cpp
+++ b/tasks/OptimalHeadingController.cpp
@@ -77,7 +77,7 @@ void OptimalHeadingController::errorHook()
 void OptimalHeadingController::keep(){
 }
 
-bool OptimalHeadingController::calcOutput(){
+bool OptimalHeadingController::calcOutput(const LinearAngular6DCommandStatus &merged_command){
     base::LinearAngular6DCommand output_command;
     double opt_heading;
     double opt_distance;
@@ -85,13 +85,13 @@ bool OptimalHeadingController::calcOutput(){
     opt_heading = _optimal_heading.get();
     opt_distance = _optimal_heading_distance.get();
 
-    output_command = merged_command;
-    
+    output_command = merged_command.command;
+
     //Set z to 0, to use only x and y fpr the distance
-    merged_command.linear(2) = 0;
-    if(merged_command.linear.norm() > opt_distance){
-        output_command.angular(2) = base::Angle::normalizeRad(atan2(merged_command.linear(1), merged_command.linear(0))
-                //+base::getYaw(orientation_sample.orientation) 
+    output_command.linear(2) = 0;
+    if(merged_command.command.linear.norm() > opt_distance){
+        output_command.angular(2) = base::Angle::normalizeRad(atan2(merged_command.command.linear(1), merged_command.command.linear(0))
+                //+base::getYaw(orientation_sample.orientation)
                 + opt_heading);
     }
     

--- a/tasks/OptimalHeadingController.cpp
+++ b/tasks/OptimalHeadingController.cpp
@@ -30,7 +30,7 @@ bool OptimalHeadingController::configureHook()
     if (! OptimalHeadingControllerBase::configureHook())
         return false;
 
-    new_orientation_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_in.value()));
+    new_orientation_samples_timeout = base::Timeout(_timeout_in.value());
 
     return true;
 }

--- a/tasks/OptimalHeadingController.hpp
+++ b/tasks/OptimalHeadingController.hpp
@@ -33,7 +33,7 @@ Frame.
         base::samples::RigidBodyState orientation_sample;
         base::Timeout new_orientation_samples_timeout;
         void keep();
-        bool calcOutput();
+        bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
 
 
     public:

--- a/tasks/PIDController.cpp
+++ b/tasks/PIDController.cpp
@@ -47,12 +47,7 @@ void PIDController::updateHook()
     if (status != RTT::NewData)
     {
         if(new_pose_samples_timeout.elapsed())
-        {
             exception(POSE_TIMEOUT);
-            return;
-        }
-        if(state() != WAIT_FOR_POSE_SAMPLE)
-            state(WAIT_FOR_POSE_SAMPLE);
         return;
     }
     new_pose_samples_timeout.restart();

--- a/tasks/PIDController.cpp
+++ b/tasks/PIDController.cpp
@@ -8,12 +8,14 @@ PIDController::PIDController(std::string const& name)
     : PIDControllerBase(name)
 {
     _variance_threshold.set(base::infinity<double>());
+    _timeout_pose.set(base::Time::fromSeconds(1));
 }
 
 PIDController::PIDController(std::string const& name, RTT::ExecutionEngine* engine)
     : PIDControllerBase(name, engine)
 {
     _variance_threshold.set(base::infinity<double>());
+    _timeout_pose.set(base::Time::fromSeconds(1));
 }
 
 PIDController::~PIDController()
@@ -31,7 +33,7 @@ bool PIDController::configureHook()
     if (! PIDControllerBase::configureHook())
         return false;
 
-    new_pose_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_pose.value()));
+    new_pose_samples_timeout = base::Timeout(_timeout_pose.get());
 
     return true;
 }

--- a/tasks/WorldToAligned.cpp
+++ b/tasks/WorldToAligned.cpp
@@ -23,7 +23,7 @@ bool WorldToAligned::configureHook()
     if (!WorldToAlignedBase::configureHook())
         return false;
 
-    new_pose_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_in.value()));
+    new_pose_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_pose.value()));
 
     return true;
 }

--- a/tasks/WorldToAligned.cpp
+++ b/tasks/WorldToAligned.cpp
@@ -7,11 +7,13 @@ using namespace auv_control;
 WorldToAligned::WorldToAligned(std::string const& name)
     : WorldToAlignedBase(name)
 {
+    _timeout_pose.set(base::Time::fromSeconds(1));
 }
 
 WorldToAligned::WorldToAligned(std::string const& name, RTT::ExecutionEngine* engine)
     : WorldToAlignedBase(name, engine)
 {
+    _timeout_pose.set(base::Time::fromSeconds(1));
 }
 
 WorldToAligned::~WorldToAligned()
@@ -23,7 +25,7 @@ bool WorldToAligned::configureHook()
     if (!WorldToAlignedBase::configureHook())
         return false;
 
-    new_pose_samples_timeout = base::Timeout(base::Time::fromSeconds(_timeout_pose.value()));
+    new_pose_samples_timeout = base::Timeout(_timeout_pose.get());
 
     return true;
 }

--- a/tasks/WorldToAligned.cpp
+++ b/tasks/WorldToAligned.cpp
@@ -107,18 +107,15 @@ void WorldToAligned::keepPosition(){
     _cmd_out.write(output_command);
 }
 
-bool WorldToAligned::calcOutput(const LinearAngular6DCommandStatus &merging_command){
+bool WorldToAligned::calcOutput(const LinearAngular6DCommandStatus &merged_command){
     // In case there is an OLD_COMMAND, it should not output the same cmd again,
     // but no error occurred
-    if (merging_command.status == OLD_COMMAND)
+    if (merged_command.status == OLD_COMMAND)
         return true;
-    return calcOutput();
-}
 
-bool WorldToAligned::calcOutput(){
     base::LinearAngular6DCommand output_command;
 
-    base::Vector3d target_xyz = merged_command.linear;
+    base::Vector3d target_xyz = merged_command.command.linear;
     if (_position_control)
         target_xyz -= currentPose.position;
 
@@ -130,7 +127,7 @@ bool WorldToAligned::calcOutput(){
     output_command.linear = Eigen::AngleAxisd(-yaw, Eigen::Vector3d::UnitZ()) * target_xy;
     output_command.linear(2) = target_xyz(2);
 
-    output_command.angular = merged_command.angular;
+    output_command.angular = merged_command.command.angular;
     if (_position_control)
     {
         // And shift the yaw target by the current yaw (leaving pitch and roll)
@@ -143,7 +140,7 @@ bool WorldToAligned::calcOutput(){
     }
         
     // Finally, set the timestamp of the output
-    output_command.time = merged_command.time;
+    output_command.time = merged_command.command.time;
     _cmd_out.write(output_command);
     return true;
 }

--- a/tasks/WorldToAligned.cpp
+++ b/tasks/WorldToAligned.cpp
@@ -108,9 +108,9 @@ void WorldToAligned::keepPosition(){
 }
 
 bool WorldToAligned::calcOutput(const LinearAngular6DCommandStatus &merged_command){
-    // In case there is an OLD_COMMAND, it should not output the same cmd again,
+    // In case there is an OldData, it should not output the same cmd again,
     // but no error occurred
-    if (merged_command.status == OLD_COMMAND)
+    if (merged_command.status == RTT::OldData)
         return true;
 
     base::LinearAngular6DCommand output_command;

--- a/tasks/WorldToAligned.hpp
+++ b/tasks/WorldToAligned.hpp
@@ -19,8 +19,7 @@ namespace auv_control {
         base::Timeout new_pose_samples_timeout;
 
         void keepPosition();
-        bool calcOutput(const LinearAngular6DCommandStatus &merging_command);
-        bool calcOutput();
+        bool calcOutput(const LinearAngular6DCommandStatus &merged_command);
         bool isPoseSampleValid(base::samples::RigidBodyState pose);
 
     public:

--- a/tasks/WorldToAligned.hpp
+++ b/tasks/WorldToAligned.hpp
@@ -19,6 +19,7 @@ namespace auv_control {
         base::Timeout new_pose_samples_timeout;
 
         void keepPosition();
+        bool calcOutput(const LinearAngular6DCommandStatus &merging_command);
         bool calcOutput();
         bool isPoseSampleValid(base::samples::RigidBodyState pose);
 

--- a/test/auv_control::PIDController.yml
+++ b/test/auv_control::PIDController.yml
@@ -79,7 +79,7 @@ parallel_pid_settings:
 pid_settings:
   linear:
   - Ts: 0.0
-    K: 1.0
+    K: 2.0
     Ti: 0.0
     Td: 0.0
     N: 0.0

--- a/test/auv_control::PIDController.yml
+++ b/test/auv_control::PIDController.yml
@@ -1,0 +1,154 @@
+--- name:default
+# Defines if the derivative will be applied to the error or to the output in the PID controller
+apply_derivative_to_error: false
+# This property defines which parts of the command input is expected to be
+# set once we merged all the declared input ports.
+expected_inputs:
+  linear:
+  - true
+  - true
+  - true
+  angular:
+  - true
+  - true
+  - true
+# If true, the component will send a zero command before getting into an
+# exception state. Otherwise, it will not do anything
+keep_position_on_exception: true
+# If true write NaN on all axis, in keep position case
+nan_on_keep_position: false
+# Parallel Settings for the PID controllers
+parallel_pid_settings:
+  linear:
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  angular:
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    Kp: 0.0
+    Ki: 0.0
+    Kd: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+# Ideal Settings for the PID controllers
+pid_settings:
+  linear:
+  - Ts: 0.0
+    K: 1.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    K: 1.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    K: 1.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  angular:
+  - Ts: 0.0
+    K: 0.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    K: 0.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+  - Ts: 0.0
+    K: 0.0
+    Ti: 0.0
+    Td: 0.0
+    N: 0.0
+    B: 1.0
+    Tt: -1.0
+    YMin: 0.0
+    YMax: 0.0
+# The command domain (true:position or false:velocity)
+position_control: true
+# This property defines the safty behavior ath the merging of the input-ports.
+# If the property is on true (default) the merged command need to be like in
+# the expected_inputs property defined. Else the expected_inputs are ignored
+# while the merged comand are unic.
+safe_mode: true
+# This property defines the timeout for the cascade input port in seconds. 0
+# means that the timeout would be ignored.
+timeout_cascade: 1.0
+# This property defines the timeout for the cmd_in input port in seconds. 0
+# means that the timeout would be ignored.
+timeout_in: 1.0
+# Use the Ideal (false) or Parallel PID-Settings
+use_parallel_pid_settings: false
+# Under this Value the axis are not controled. Output is 0.
+variance_threshold: .inf
+# The command frame (true:world or false:aligned)
+world_frame: false

--- a/test/auv_control::PIDController.yml
+++ b/test/auv_control::PIDController.yml
@@ -14,7 +14,7 @@ expected_inputs:
   - true
 # If true, the component will send a zero command before getting into an
 # exception state. Otherwise, it will not do anything
-keep_position_on_exception: true
+keep_position_on_exception: false
 # If true write NaN on all axis, in keep position case
 nan_on_keep_position: false
 # Parallel Settings for the PID controllers

--- a/test/auv_control::PIDController.yml
+++ b/test/auv_control::PIDController.yml
@@ -142,10 +142,12 @@ position_control: true
 safe_mode: true
 # This property defines the timeout for the cascade input port in seconds. 0
 # means that the timeout would be ignored.
-timeout_cascade: 1.0
+timeout_cascade:
+    microseconds: 1000000
 # This property defines the timeout for the cmd_in input port in seconds. 0
 # means that the timeout would be ignored.
-timeout_in: 1.0
+timeout_in:
+    microseconds: 1000000
 # Use the Ideal (false) or Parallel PID-Settings
 use_parallel_pid_settings: false
 # Under this Value the axis are not controled. Output is 0.

--- a/test/auv_control::WorldToAligned.yml
+++ b/test/auv_control::WorldToAligned.yml
@@ -1,0 +1,31 @@
+--- name:default
+# This property defines which parts of the command input is expected to be
+# set once we merged all the declared input ports.
+expected_inputs:
+  linear:
+  - true
+  - true
+  - true
+  angular:
+  - true
+  - true
+  - true
+# If true, the component will send a zero command before getting into an
+# exception state. Otherwise, it will not do anything
+keep_position_on_exception: false
+# If true write NaN on all axis, in keep position case
+nan_on_keep_position: false
+# The domain of what we are converting (true:position or false:velocity or
+# efforts)
+position_control: false
+# This property defines the safty behavior ath the merging of the input-ports.
+# If the property is on true (default) the merged command need to be like in
+# the expected_inputs property defined. Else the expected_inputs are ignored
+# while the merged comand are unic.
+safe_mode: true
+# This property defines the timeout for the cascade input port in seconds. 0
+# means that the timeout would be ignored.
+timeout_cascade: 1.0
+# This property defines the timeout for the cmd_in input port in seconds. 0
+# means that the timeout would be ignored.
+timeout_in: 1.0

--- a/test/auv_control::WorldToAligned.yml
+++ b/test/auv_control::WorldToAligned.yml
@@ -25,7 +25,9 @@ position_control: false
 safe_mode: true
 # This property defines the timeout for the cascade input port in seconds. 0
 # means that the timeout would be ignored.
-timeout_cascade: 1.0
+timeout_cascade:
+    microseconds: 1000000
 # This property defines the timeout for the cmd_in input port in seconds. 0
 # means that the timeout would be ignored.
-timeout_in: 1.0
+timeout_in:
+    microseconds: 1000000

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -11,16 +11,16 @@ describe 'auv_control::Base' do
     reader 'task', 'cmd_out', :attr_name => 'cmd_out'
 
         it "should create a port with the given name prefixed with cmd_" do
-            task.addCommandInput('test', 0)
+            task.addCommandInput('test', Time.at(0))
             port = task.cmd_test
             assert_equal '/base/commands/LinearAngular6DCommand_m', port.type.name
         end
         it "should return true when the port could be created" do
-            assert task.addCommandInput('test', 0)
+            assert task.addCommandInput('test', Time.at(0))
         end
         it "should return false when the port already exists" do
-            task.addCommandInput('test', 0)
-            refute task.addCommandInput('test', 0)
+            task.addCommandInput('test', Time.at(0))
+            refute task.addCommandInput('test', Time.at(0))
         end
 
         before do
@@ -47,8 +47,8 @@ describe 'auv_control::Base' do
         end
 
         it "should merge all its inputs" do
-            task.addCommandInput '0', 0
-            task.addCommandInput '1', 0
+            task.addCommandInput '0', Time.at(0)
+            task.addCommandInput '1', Time.at(0)
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
             pose = task.pose_samples.writer
@@ -73,7 +73,7 @@ describe 'auv_control::Base' do
             assert Base.unset?(merged.angular[2])
         end
         it "should use the cmd_in port if it is connected" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_in.writer
             pose = task.pose_samples.writer
@@ -98,7 +98,7 @@ describe 'auv_control::Base' do
             assert Base.unset?(merged.angular[2])
         end
         it "should use the cmd_cascade port if it is connected" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_cascade.writer
             pose = task.pose_samples.writer
@@ -123,7 +123,7 @@ describe 'auv_control::Base' do
             assert Base.unset?(merged.angular[2])
         end
         it "should go in INPUT_MISSING state if an expected input is not there" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
 
@@ -137,8 +137,8 @@ describe 'auv_control::Base' do
             assert_state_change(task) { |s| s == :INPUT_MISSING }
         end
         it "should go in INPUT_COLLIDING state if two inputs provide the same value" do
-            task.addCommandInput '0', 0
-            task.addCommandInput '1', 0
+            task.addCommandInput '0', Time.at(0)
+            task.addCommandInput '1', Time.at(0)
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
             pose = task.pose_samples.writer
@@ -156,7 +156,7 @@ describe 'auv_control::Base' do
             assert_state_change(task) { |s| s == :INPUT_COLLIDING }
         end
         it "should go in INPUT_UNEXPECTED state if there is a value for an unexpected input" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
 
@@ -172,7 +172,7 @@ describe 'auv_control::Base' do
             assert_state_change(task) { |s| s == :INPUT_UNEXPECTED }
         end
         it "should go in TIMEOUT state if one port is not updated for its specified timeout and recover in case of new data" do
-            task.addCommandInput '0', 1
+            task.addCommandInput '0', Time.at(1)
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
             task.timeout_pose = Time.at(10)
@@ -202,7 +202,7 @@ describe 'auv_control::Base' do
             assert_equal :CONTROLLING, task.state_reader.read
         end
         it "should not check for timeouts on ports that have a timeout value of zero" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
             task.timeout_pose = Time.at(10)
@@ -223,8 +223,8 @@ describe 'auv_control::Base' do
             assert_state_change(task) { |s| s != :TIMEOUT }
         end
         it "should wait in WAIT_FOR_INPUT state if there is no data on one of the input ports" do
-            task.addCommandInput '0', 0
-            task.addCommandInput '1', 0
+            task.addCommandInput '0', Time.at(0)
+            task.addCommandInput '1', Time.at(0)
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
             pose = task.pose_samples.writer
@@ -240,7 +240,7 @@ describe 'auv_control::Base' do
         end
 
         it "should delete all created ports" do
-            task.addCommandInput '0', 0
+            task.addCommandInput '0', Time.at(0)
             task.configure
             task.cleanup
         end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -1,4 +1,4 @@
-require 'pry'
+require 'minitest/autorun'
 require 'minitest/spec'
 require 'orocos/test/component'
 
@@ -7,10 +7,9 @@ describe 'auv_control::Base' do
 
     # We cannot instanciate an auv_control::Base component, as it is abstract.
     # Instead, use WorldToAligned to test the Base functionality
-    start 'task', 'tests_auv_control::Base'
+    start 'task', 'auv_control::WorldToAligned' => 'task'
     reader 'task', 'cmd_out', :attr_name => 'cmd_out'
 
-    describe "addCommandInput" do
         it "should create a port with the given name prefixed with cmd_" do
             task.addCommandInput 'test', 0
             port = task.cmd_test
@@ -23,9 +22,7 @@ describe 'auv_control::Base' do
             task.addCommandInput('test', 0)
             refute task.addCommandInput('test', 0)
         end
-    end
 
-    describe "updateHook" do
         before do
             task.expected_inputs do |v|
                 v.linear[0] = 1
@@ -189,13 +186,10 @@ describe 'auv_control::Base' do
             cmd0.write sample
             assert_state_change(task) { |s| s == :WAIT_FOR_INPUT }
         end
-    end
 
-    describe "cleanupHook" do
         it "should delete all created ports" do
             task.addCommandInput '0', 0
             task.configure
             task.cleanup
         end
-    end
 end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -175,7 +175,7 @@ describe 'auv_control::Base' do
             task.addCommandInput '0', 1
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
-            task.timeout_pose = 10
+            task.timeout_pose = Time.at(10)
             task.keep_position_on_exception = false
 
             task.configure
@@ -205,7 +205,7 @@ describe 'auv_control::Base' do
             task.addCommandInput '0', 0
             cmd0 = task.cmd_0.writer
             pose = task.pose_samples.writer
-            task.timeout_pose = 10
+            task.timeout_pose = Time.at(10)
             task.configure
             task.start
             sample = invalidated_command

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -11,9 +11,9 @@ describe 'auv_control::Base' do
     reader 'task', 'cmd_out', :attr_name => 'cmd_out'
 
         it "should create a port with the given name prefixed with cmd_" do
-            task.addCommandInput 'test', 0
+            task.addCommandInput('test', 0)
             port = task.cmd_test
-            assert_equal '/base/LinearAngular6DCommand_m', port.type.name
+            assert_equal '/base/commands/LinearAngular6DCommand_m', port.type.name
         end
         it "should return true when the port could be created" do
             assert task.addCommandInput('test', 0)
@@ -38,12 +38,22 @@ describe 'auv_control::Base' do
             sample
         end
 
+        def pose_sample
+            sample = task.pose_samples.new_sample
+            sample.time = Time.now
+            sample.position = sample.velocity = sample.angular_velocity = Eigen::Vector3.new(0, 0, 0)
+            sample.orientation = Eigen::Quaternion.Identity
+            sample
+        end
+
         it "should merge all its inputs" do
             task.addCommandInput '0', 0
             task.addCommandInput '1', 0
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
-            
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
@@ -52,8 +62,9 @@ describe 'auv_control::Base' do
             sample = invalidated_command
             sample.linear[1] = 2
             cmd1.write sample
+            pose.write pose_sample
 
-            merged = assert_has_one_new_sample cmd_out, 10
+            merged = assert_has_one_new_sample cmd_out, 1
             assert_in_delta 1, merged.linear[0], 1e-6
             assert_in_delta 2, merged.linear[1], 1e-6
             assert Base.unset?(merged.linear[2])
@@ -65,7 +76,9 @@ describe 'auv_control::Base' do
             task.addCommandInput '0', 0
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_in.writer
-            
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
@@ -74,6 +87,7 @@ describe 'auv_control::Base' do
             sample = invalidated_command
             sample.linear[1] = 2
             cmd1.write sample
+            pose.write pose_sample
 
             merged = assert_has_one_new_sample cmd_out, 10
             assert_in_delta 1, merged.linear[0], 1e-6
@@ -87,7 +101,9 @@ describe 'auv_control::Base' do
             task.addCommandInput '0', 0
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_cascade.writer
-            
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
@@ -96,6 +112,7 @@ describe 'auv_control::Base' do
             sample = invalidated_command
             sample.linear[1] = 2
             cmd1.write sample
+            pose.write pose_sample
 
             merged = assert_has_one_new_sample cmd_out, 10
             assert_in_delta 1, merged.linear[0], 1e-6
@@ -108,10 +125,14 @@ describe 'auv_control::Base' do
         it "should go in INPUT_MISSING state if an expected input is not there" do
             task.addCommandInput '0', 0
             cmd0 = task.cmd_0.writer
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
             sample.linear[0] = 1
+            pose.write pose_sample
             cmd0.write sample
             assert_state_change(task) { |s| s == :INPUT_MISSING }
         end
@@ -120,8 +141,12 @@ describe 'auv_control::Base' do
             task.addCommandInput '1', 0
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
+            pose.write pose_sample
             sample = invalidated_command
             sample.linear[0] = 1
             sample.linear[1] = 1
@@ -133,6 +158,9 @@ describe 'auv_control::Base' do
         it "should go in INPUT_UNEXPECTED state if there is a value for an unexpected input" do
             task.addCommandInput '0', 0
             cmd0 = task.cmd_0.writer
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
@@ -140,50 +168,66 @@ describe 'auv_control::Base' do
             sample.linear[1] = 1
             sample.linear[2] = 1
             cmd0.write sample
+            pose.write pose_sample
             assert_state_change(task) { |s| s == :INPUT_UNEXPECTED }
         end
-        it "should go in TIMEOUT state if one port is not updated for its specified timeout" do
-            task.addCommandInput '0', 1
-            cmd0 = task.cmd_0.writer
-            task.configure
-            task.start
-            sample = invalidated_command
-            sample.linear[0] = 1
-            sample.linear[1] = 1
-            cmd0.write sample
-            sample = invalidated_command
-            sample.time = Time.now + 2
-            sample.linear[0] = 1
-            sample.linear[1] = 1
-            cmd0.write sample
-            assert_state_change(task) { |s| s == :TIMEOUT }
-        end
-        it "should not check for timeouts on ports that have a timeout value of zero" do
-            task.addCommandInput '0', 0
-            cmd0 = task.cmd_0.writer
-            task.configure
-            task.start
-            sample = invalidated_command
-            sample.linear[0] = 1
-            sample.linear[1] = 1
-            cmd0.write sample
-            sample = invalidated_command
-            sample.time = Time.now + 1000
-            sample.linear[0] = 1
-            sample.linear[1] = 1
-            cmd0.write sample
-            assert_state_change(task) { |s| s == :TIMEOUT }
-        end
+        # it "should go in TIMEOUT state if one port is not updated for its specified timeout" do
+        #     task.addCommandInput '0', 1
+        #     cmd0 = task.cmd_0.writer
+        #     pose = task.pose_samples.writer
+        #     task.configure
+        #     task.start
+        #     sample = invalidated_command
+        #     sample.linear[0] = 1
+        #     sample.linear[1] = 1
+        #     cmd0.write sample
+        #     pos = pose_sample
+        #     pose.write pos
+        #     puts "sample.time: #{sample.time} + #{sample.time.usec}"
+        #     sample = invalidated_command
+        #     sample.time = Time.now + 2
+        #     puts "sample.time2: #{sample.time} + #{sample.time.usec}"
+        #     sample.linear[0] = 1
+        #     sample.linear[1] = 1
+        #     cmd0.write sample
+        #     pos.time = Time.now
+        #     pose.write pos
+        #     sleep(0.01)
+        #     assert_state_change(task) { |s| s == :TIMEOUT }
+        # end
+        # it "should not check for timeouts on ports that have a timeout value of zero" do
+        #     task.addCommandInput '0', 0
+        #     cmd0 = task.cmd_0.writer
+        #     pose = task.pose_samples.writer
+        #     task.configure
+        #     task.start
+        #     sample = invalidated_command
+        #     sample.linear[0] = 1
+        #     sample.linear[1] = 1
+        #     cmd0.write sample
+        #     pose.write pose_sample
+        #     sample = invalidated_command
+        #     sample.time = Time.now + 1000
+        #     sample.linear[0] = 1
+        #     sample.linear[1] = 1
+        #     cmd0.write sample
+        #     pose.write pose_sample
+        #     assert_state_change(task) { |s| s != :TIMEOUT }
+        # end
         it "should wait in WAIT_FOR_INPUT state if there is no data on one of the input ports" do
             task.addCommandInput '0', 0
             task.addCommandInput '1', 0
             cmd0 = task.cmd_0.writer
             cmd1 = task.cmd_1.writer
+            pose = task.pose_samples.writer
+
+            task.keep_position_on_exception = false
             task.configure
             task.start
             sample = invalidated_command
             sample.linear[0] = 1
             cmd0.write sample
+            pose.write pose_sample
             assert_state_change(task) { |s| s == :WAIT_FOR_INPUT }
         end
 
@@ -191,5 +235,23 @@ describe 'auv_control::Base' do
             task.addCommandInput '0', 0
             task.configure
             task.cleanup
+        end
+
+        it "should go to WAIT_FOR_CONNECTED_INPUT_PORT state when no port is connected" do
+            pose = task.pose_samples.writer
+            task.keep_position_on_exception = false
+            task.configure
+            task.start
+            pose.write pose_sample
+            assert_state_change(task) { |s| s == :WAIT_FOR_CONNECTED_INPUT_PORT }
+        end
+
+        it "should NOT go to WAIT_FOR_CONNECTED_INPUT_PORT state when at least one port is connected" do
+            pose = task.pose_samples.writer
+            cmd = task.cmd_in.writer
+            task.configure
+            task.start
+            pose.write pose_sample
+            assert_state_change(task) { |s| s != :WAIT_FOR_CONNECTED_INPUT_PORT }
         end
 end

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -9,6 +9,22 @@ describe 'auv_control::PIDController' do
     writer 'pid', 'cmd_in', :attr_name => 'cmd_in'
     writer 'pid', 'pose_samples', :attr_name => 'pose_samples'
 
+    def generate_default_pose
+        pose_sample = pid.pose_samples.new_sample
+        pose_sample.position = pose_sample.velocity = pose_sample.angular_velocity = Eigen::Vector3.new(0, 0, 0)
+        pose_sample.orientation = Eigen::Quaternion.Identity
+        pose_sample.time = Time.now
+        pose_sample
+    end
+
+    def generate_default_cmd
+        set_point = pid.cmd_in.new_sample
+        set_point.linear = Eigen::Vector3.new(1, 0, 0)
+        set_point.angular = Eigen::Vector3.new(0, 0, 0)
+        set_point.time = Time.now
+        set_point
+    end
+
     it "should not provide output samples with same timestamp" do
 
         pid.apply_conf_file("auv_control::PIDController.yml")
@@ -16,18 +32,10 @@ describe 'auv_control::PIDController' do
         pid.configure
         pid.start
 
-        set_point = pid.cmd_in.new_sample
-        set_point.time = Time.now
-        set_point.linear = Eigen::Vector3.new(1, 0, 0)
-        set_point.angular = Eigen::Vector3.new(0, 0, 0)
+        pose_sample = generate_default_pose
+        set_point = generate_default_cmd
 
         cmd_in.write set_point
-
-        pose_sample = pid.pose_samples.new_sample
-        pose_sample.position = Eigen::Vector3.new(0, 0, 0)
-        pose_sample.velocity = Eigen::Vector3.new(0, 0, 0)
-        pose_sample.angular_velocity = Eigen::Vector3.new(0, 0, 0)
-        pose_sample.orientation = Eigen::Quaternion.Identity
 
         for i in 0..3
             pose_sample.time = Time.now
@@ -36,18 +44,57 @@ describe 'auv_control::PIDController' do
             puts "set_point.time: #{set_point.time} + #{set_point.time.usec}"
             pose_samples.write pose_sample
             cmd_in.write set_point
-            assert_state_change(pid) { |s| s == :RUNNING }
             cmd_out0 = assert_has_one_new_sample cmd_out, 1
-            puts "cmd_out0.time: #{cmd_out0.time} + #{cmd_out0.time.usec}"
-            for j in 1..10
-                sleep(0.01)
-                # It was supposed to output an cmd_out here???? WIth repeated timestamp???
-                cmd_out1 = assert_has_one_new_sample cmd_out, 1
-                puts "cmd_out#{j}.time: #{cmd_out1.time} + #{cmd_out1.time.usec}"
+            puts "cmd_out.time: #{cmd_out0.time} + #{cmd_out0.time.usec}"
+            for j in 1..5
+                # No more repeated sample here.
+                cmd_out1 = assert_has_no_new_sample cmd_out, 0.01
             end
             puts " "
         end
+    end
 
+    it "should go to exception POSE_TIMEOUT" do
+
+        pid.apply_conf_file("auv_control::PIDController.yml")
+
+        pid.configure
+        pid.start
+
+        pose_sample = generate_default_pose
+        set_point = generate_default_cmd
+
+        pose_samples.write pose_sample
+        cmd_in.write set_point
+        cmd_out0 = assert_has_one_new_sample cmd_out, 1
+        sleep(pid.timeout_in)
+        assert_state_change(pid) { |s| s == :POSE_TIMEOUT }
+    end
+
+    it "should not crash with just one set_point" do
+
+        pid.apply_conf_file("auv_control::PIDController.yml")
+
+        pid.configure
+        pid.start
+
+        pose_sample = generate_default_pose
+        set_point = generate_default_cmd
+        cmd_in.write set_point
+
+        for i in 0..3
+            pose_sample.time = Time.now
+            puts "pose_sample.time: #{pose_sample.time} + #{pose_sample.time.usec}"
+            puts "set_point.time: #{set_point.time} + #{set_point.time.usec}"
+            pose_samples.write pose_sample
+            cmd_out0 = assert_has_one_new_sample cmd_out, 1
+            puts "cmd_out0.time: #{cmd_out0.time} + #{cmd_out0.time.usec}"
+            for j in 1..5
+                # No more repeated sample here.
+                cmd_out1 = assert_has_no_new_sample cmd_out, 0.01
+            end
+            puts " "
+        end
     end
 
 end

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -1,0 +1,53 @@
+require 'minitest/spec'
+require 'orocos/test/component'
+require 'minitest/autorun'
+
+describe 'auv_control::PIDController' do
+    include Orocos::Test::Component
+    start  'pid', 'auv_control::PIDController' => 'pid'
+    reader 'pid', 'cmd_out', :attr_name => 'cmd_out'
+    writer 'pid', 'cmd_in', :attr_name => 'cmd_in'
+    writer 'pid', 'pose_samples', :attr_name => 'pose_samples'
+
+    it "should not provide output samples with same timestamp" do
+
+        pid.apply_conf_file("auv_control::PIDController.yml")
+
+        pid.configure
+        pid.start
+
+        set_point = pid.cmd_in.new_sample
+        set_point.time = Time.now
+        set_point.linear = Eigen::Vector3.new(1, 0, 0)
+        set_point.angular = Eigen::Vector3.new(0, 0, 0)
+
+        cmd_in.write set_point
+
+        pose_sample = pid.pose_samples.new_sample
+        pose_sample.position = Eigen::Vector3.new(0, 0, 0)
+        pose_sample.velocity = Eigen::Vector3.new(0, 0, 0)
+        pose_sample.angular_velocity = Eigen::Vector3.new(0, 0, 0)
+        pose_sample.orientation = Eigen::Quaternion.Identity
+
+        for i in 0..3
+            pose_sample.time = Time.now
+            set_point.time = Time.now
+            puts "pose_sample.time: #{pose_sample.time} + #{pose_sample.time.usec}"
+            puts "set_point.time: #{set_point.time} + #{set_point.time.usec}"
+            pose_samples.write pose_sample
+            cmd_in.write set_point
+            assert_state_change(pid) { |s| s == :RUNNING }
+            cmd_out0 = assert_has_one_new_sample cmd_out, 1
+            puts "cmd_out0.time: #{cmd_out0.time} + #{cmd_out0.time.usec}"
+            for j in 1..10
+                sleep(0.01)
+                # It was supposed to output an cmd_out here???? WIth repeated timestamp???
+                cmd_out1 = assert_has_one_new_sample cmd_out, 1
+                puts "cmd_out#{j}.time: #{cmd_out1.time} + #{cmd_out1.time.usec}"
+            end
+            puts " "
+        end
+
+    end
+
+end

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -66,7 +66,7 @@ describe 'auv_control::PIDController' do
         cmd_in.write set_point
         cmd_out0 = assert_has_one_new_sample cmd_out, 0.1
         assert_state_change(pid) { |s| s == :CONTROLLING }
-        sleep(pid.timeout_in)
+        sleep(pid.timeout_pose.to_i)
         assert_state_change(pid) { |s| s == :POSE_TIMEOUT }
     end
 

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -74,7 +74,7 @@ describe 'auv_control::PIDController' do
 
         pid.apply_conf_file("auv_control::PIDController.yml")
         pid.variance_threshold = 1
-        pid.timeout_in = 10
+        pid.timeout_in = Time.at(10)
 
         pid.configure
         pid.start
@@ -94,7 +94,7 @@ describe 'auv_control::PIDController' do
     it "should not crash with just one set_point" do
 
         pid.apply_conf_file("auv_control::PIDController.yml")
-        pid.timeout_in = 10
+        pid.timeout_in = Time.at(10)
 
         pid.configure
         pid.start
@@ -119,7 +119,7 @@ describe 'auv_control::PIDController' do
     it "should provide the correct output according the pose_sample, considering auv moving along X axis only" do
 
         pid.apply_conf_file("auv_control::PIDController.yml")
-        pid.timeout_in = 10
+        pid.timeout_in = Time.at(10)
         pid.position_control = true
         pid.world_frame = true
         # The gains other than K are zero

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -122,6 +122,7 @@ describe 'auv_control::PIDController' do
         pid.timeout_in = 10
         pid.position_control = true
         pid.world_frame = true
+        # The gains other than K are zero
         gainK = pid.pid_settings.linear[0].K
 
         pid.configure

--- a/test/test_world_to_aligned.rb
+++ b/test/test_world_to_aligned.rb
@@ -58,7 +58,7 @@ describe 'auv_control::WorldToAligned' do
     it "should go to exception POSE_TIMEOUT" do
 
         world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
-
+        world_to_aligned.timeout_in = world_to_aligned.timeout_pose.to_i+1
         world_to_aligned.configure
         world_to_aligned.start
 
@@ -72,7 +72,7 @@ describe 'auv_control::WorldToAligned' do
         cmd_in.write generate_default_cmd
         assert_state_change(world_to_aligned) { |s| s == :CONTROLLING }
         cmd_out0 = assert_has_one_new_sample cmd_out, 0.1
-        sleep(world_to_aligned.timeout_in)
+        sleep(world_to_aligned.timeout_pose.to_i)
         cmd_out0 = assert_has_no_new_sample cmd_out, 0.1
         assert_equal :POSE_TIMEOUT, world_to_aligned.state_reader.read
     end

--- a/test/test_world_to_aligned.rb
+++ b/test/test_world_to_aligned.rb
@@ -1,0 +1,142 @@
+require 'minitest/spec'
+require 'orocos/test/component'
+require 'minitest/autorun'
+
+describe 'auv_control::WorldToAligned' do
+    include Orocos::Test::Component
+    start  'world_to_aligned', 'auv_control::WorldToAligned' => 'world_to_aligned'
+    reader 'world_to_aligned', 'cmd_out', :attr_name => 'cmd_out'
+    writer 'world_to_aligned', 'cmd_in', :attr_name => 'cmd_in'
+    writer 'world_to_aligned', 'pose_samples', :attr_name => 'pose_samples'
+
+    def generate_default_pose
+        pose_sample = world_to_aligned.pose_samples.new_sample
+        pose_sample.position = pose_sample.velocity = pose_sample.angular_velocity = Eigen::Vector3.new(0, 0, 0)
+        pose_sample.orientation = Eigen::Quaternion.Identity
+        pose_sample.time = Time.now
+        pose_sample
+    end
+
+    def generate_default_cmd
+        cmd_in = world_to_aligned.cmd_in.new_sample
+        cmd_in.linear = Eigen::Vector3.new(1, 0, 0)
+        cmd_in.angular = Eigen::Vector3.new(0, 0, 0)
+        cmd_in.time = Time.now
+        cmd_in
+    end
+
+    it "should create a port with the given name prefixed with cmd_" do
+        world_to_aligned.addCommandInput 'test', 0
+        port = world_to_aligned.cmd_test
+        assert_equal '/base/commands/LinearAngular6DCommand_m', port.type.name
+    end
+
+    it "should not provide output samples with same timestamp" do
+
+        world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
+
+        world_to_aligned.configure
+        world_to_aligned.start
+
+        pose_sample = generate_default_pose
+        cmd = generate_default_cmd
+
+        for i in 0..3
+            pose_sample.time = Time.now
+            cmd.time = Time.now
+            pose_samples.write pose_sample
+            cmd_in.write cmd
+            cmd_out0 = assert_has_one_new_sample cmd_out, 1
+            assert_equal cmd.time.usec, cmd_out0.time.usec
+            for j in 1..5
+                # No more repeated sample here.
+                cmd_out1 = assert_has_no_new_sample cmd_out, 0.1
+            end
+        end
+    end
+
+    it "should go to exception POSE_TIMEOUT" do
+
+        world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
+
+        world_to_aligned.configure
+        world_to_aligned.start
+
+        pose_sample = generate_default_pose
+        cmd = generate_default_cmd
+
+        pose_samples.write pose_sample
+        cmd_in.write cmd
+        cmd_out0 = assert_has_one_new_sample cmd_out, 0.1
+        # sleep(world_to_aligned.timeout_in)
+        cmd_in.write generate_default_cmd
+        assert_state_change(world_to_aligned) { |s| s == :CONTROLLING }
+        cmd_out0 = assert_has_one_new_sample cmd_out, 0.1
+        sleep(world_to_aligned.timeout_in)
+        cmd_out0 = assert_has_no_new_sample cmd_out, 0.1
+        assert_equal :POSE_TIMEOUT, world_to_aligned.state_reader.read
+    end
+
+    it "should not crash with just one pose_sample" do
+
+        world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
+
+        world_to_aligned.configure
+        world_to_aligned.start
+
+        pose_sample = generate_default_pose
+        cmd = generate_default_cmd
+        pose_samples.write pose_sample
+        cmd_in.write cmd
+
+        for i in 0..3
+            cmd.time = Time.now
+            cmd_in.write cmd
+            cmd_out0 = assert_has_one_new_sample cmd_out, 1
+            assert_equal cmd.time.usec, cmd_out0.time.usec
+            for j in 1..5
+                # No more repeated sample here.
+                cmd_out1 = assert_has_no_new_sample cmd_out, 0.01
+            end
+        end
+    end
+
+    it "should provide output samples even in case there is one sample in input_port" do
+        cmd_cascade = world_to_aligned.cmd_cascade.writer
+
+        world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
+
+        world_to_aligned.configure
+        world_to_aligned.start
+
+        pose_sample = generate_default_pose
+        cmd = world_to_aligned.cmd_in.new_sample
+        cmd.angular = Eigen::Vector3.Unset
+        cmd.time = Time.now
+        cmd_c = world_to_aligned.cmd_in.new_sample
+        cmd_c.linear = Eigen::Vector3.Unset
+        cmd_c.time = Time.now
+        sleep(0.01)
+        assert_equal :WAIT_FOR_POSE_SAMPLE, world_to_aligned.state_reader.read
+
+        for i in 0..3
+            pose_sample.time = Time.now
+            cmd.time = Time.now
+            cmd_c.time = Time.now
+            pose_samples.write pose_sample
+            cmd_in.write cmd
+            cmd_cascade.write cmd_c
+            cmd_out0 = assert_has_one_new_sample cmd_out, 1
+            # The latest command
+            assert_equal cmd_c.time.usec, cmd_out0.time.usec
+            for j in 1..5
+                # No more repeated sample here.
+                cmd_c.time = Time.now
+                cmd_cascade.write cmd_c
+                cmd_out1 = assert_has_one_new_sample cmd_out, 0.1
+                assert_equal cmd_c.time.usec, cmd_out1.time.usec
+            end
+        end
+    end
+
+end

--- a/test/test_world_to_aligned.rb
+++ b/test/test_world_to_aligned.rb
@@ -26,7 +26,7 @@ describe 'auv_control::WorldToAligned' do
     end
 
     it "should create a port with the given name prefixed with cmd_" do
-        world_to_aligned.addCommandInput 'test', 0
+        world_to_aligned.addCommandInput 'test', Time.at(0)
         port = world_to_aligned.cmd_test
         assert_equal '/base/commands/LinearAngular6DCommand_m', port.type.name
     end
@@ -58,7 +58,7 @@ describe 'auv_control::WorldToAligned' do
     it "should go to exception POSE_TIMEOUT" do
 
         world_to_aligned.apply_conf_file("auv_control::WorldToAligned.yml")
-        world_to_aligned.timeout_in = world_to_aligned.timeout_pose.to_i+1
+        world_to_aligned.timeout_in = Time.at(world_to_aligned.timeout_pose.to_i+1)
         world_to_aligned.configure
         world_to_aligned.start
 


### PR DESCRIPTION
Every step a sample of cmd_out is output even in case there is no new
data in cmd_in or pose_samples.
The timestamp of cmd_out is defined by cmd_in
