### PR TITLE
Move LinearAngular6DCommand to base/types

### DIFF
--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -6,6 +6,7 @@
 #include <base/Time.hpp>
 #include <base/Eigen.hpp>
 #include <base/Float.hpp>
+#include <base/commands/LinearAngular6DCommand.hpp>
 
 namespace auv_control{
     struct ExpectedInputs{
@@ -30,37 +31,6 @@ namespace auv_control{
 }    
 
 namespace base{
-    /** Common command structure for all controller types, in all control frames */
-    struct LinearAngular6DCommand{
-        /** The command timestamp */
-        base::Time time;
-        /** The linear part of the command, as (x,y,z) */
-        base::Vector3d linear;
-        /** The angular part of the command, as (r,p,y) */
-        base::Vector3d angular;
-
-        LinearAngular6DCommand(){
-            for(int i = 0; i < 3; i++){
-                linear(i) = base::unset<double>();
-                angular(i) = base::unset<double>();
-            }
-        }
-
-        double& x() { return linear(0); }
-        double& y() { return linear(1); }
-        double& z() { return linear(2); }
-        double& roll() { return angular(0); }
-        double& pitch() { return angular(1); }
-        double& yaw() { return angular(2); }
-
-        double x() const { return linear(0); }
-        double y() const { return linear(1); }
-        double z() const { return linear(2); }
-        double roll() const { return angular(0); }
-        double pitch() const { return angular(1); }
-        double yaw() const { return angular(2); }
-    };
-
     struct LinearAngular6DWaypoint{
         LinearAngular6DCommand cmd;
         double opt_orientation;


### PR DESCRIPTION
@saarnold @doudou 

I've moved LinearAngular6DCommand from auv_control to base/types, since previously many other components had to depend on auv_control only to have access to this specific type. I put the type into base/commands namespace and created a typedef inside base to guarantee backwards compatibility. These changes can be seen in https://github.com/rock-core/base-types/pull/96.

In this PR I've:

   1) Removed LinearAngular6DCommand's definition from auv_control
   2) Exported LinearAngular6DCommand (which is now imported from base) in order to guarantee backwards compatibility

This PR depends on:
- [x] - https://github.com/rock-core/base-types/pull/96
- [x] - https://github.com/rock-core/base-orogen-types/pull/22
