### PR TITLE
Remove inappropriate comma

### DIFF
--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -67,7 +67,7 @@ void Base::updateHook()
         return;
     }
     // Switch to specific Running state defined in Base
-    if(state() != stat);
+    if(state() != stat)
         state(stat);
 }
 


### PR DESCRIPTION
Due to this comma, the state was being always set, even if it hadn't changed