### PR TITLE
Restart timeout start hook

### DIFF
--- a/tasks/AlignedToBody.cpp
+++ b/tasks/AlignedToBody.cpp
@@ -40,7 +40,9 @@ bool AlignedToBody::startHook()
     on_init = true;
     if (! AlignedToBodyBase::startHook())
         return false;
-    
+
+    new_orientation_samples_timeout.restart();
+
     auv_control::ExpectedInputs expect(_expected_inputs.get());
     return validateInputExpectations(expect.linear, "linear") &&
         validateInputExpectations(expect.angular, "angular");
@@ -89,7 +91,7 @@ void AlignedToBody::updateHook()
         }
         return;
     }
-    
+
     AlignedToBodyBase::updateHook();
 
     on_init = false;

--- a/tasks/OptimalHeadingController.cpp
+++ b/tasks/OptimalHeadingController.cpp
@@ -38,6 +38,9 @@ bool OptimalHeadingController::startHook()
 {
     if (! OptimalHeadingControllerBase::startHook())
         return false;
+
+    new_orientation_samples_timeout.restart();
+
     return true;
 }
 void OptimalHeadingController::updateHook()
@@ -58,7 +61,7 @@ void OptimalHeadingController::updateHook()
     else{
         new_orientation_samples_timeout.restart();
     }
-    
+
     OptimalHeadingControllerBase::updateHook();
 }
 
@@ -94,7 +97,7 @@ bool OptimalHeadingController::calcOutput(const LinearAngular6DCommandStatus &me
                 //+base::getYaw(orientation_sample.orientation)
                 + opt_heading);
     }
-    
+
     //write the command
     _cmd_out.write(output_command);
 

--- a/tasks/PIDController.cpp
+++ b/tasks/PIDController.cpp
@@ -41,6 +41,9 @@ bool PIDController::startHook()
 {
     if (! PIDControllerBase::startHook())
         return false;
+
+    new_pose_samples_timeout.restart();
+
     return true;
 }
 void PIDController::updateHook()

--- a/tasks/WorldToAligned.cpp
+++ b/tasks/WorldToAligned.cpp
@@ -43,6 +43,8 @@ bool WorldToAligned::startHook()
         return false;
     }
 
+    new_pose_samples_timeout.restart();
+
     return true;
 }
 void WorldToAligned::updateHook()
@@ -84,10 +86,10 @@ void WorldToAligned::errorHook()
 void WorldToAligned::keepPosition(){
     base::LinearAngular6DCommand output_command;
     output_command.time = currentPose.time;
-    
+
     if(!_nan_on_keep_position.get()){
-        output_command.linear(0) = 0; 
-        output_command.linear(1) = 0; 
+        output_command.linear(0) = 0;
+        output_command.linear(1) = 0;
         output_command.linear(2) = 0;
 
         output_command.roll() = base::getRoll(currentPose.orientation);
@@ -138,7 +140,7 @@ bool WorldToAligned::calcOutput(const LinearAngular6DCommandStatus &merged_comma
             output_command.angular(2)+=(2*M_PI);
 
     }
-        
+
     // Finally, set the timestamp of the output
     output_command.time = merged_command.command.time;
     _cmd_out.write(output_command);
@@ -146,19 +148,19 @@ bool WorldToAligned::calcOutput(const LinearAngular6DCommandStatus &merged_comma
 }
 
 bool WorldToAligned::isPoseSampleValid(base::samples::RigidBodyState pose){
-    if((!_safe_mode.get()) && 
-            (!base::samples::RigidBodyState::isValidValue(pose.position) || 
+    if((!_safe_mode.get()) &&
+            (!base::samples::RigidBodyState::isValidValue(pose.position) ||
              (!base::samples::RigidBodyState::isValidValue(pose.orientation)))){
         return false;
     } else {
         auv_control::ExpectedInputs expected_inputs = _expected_inputs.get();
-        if((expected_inputs.linear[0] || expected_inputs.linear[1]) && 
+        if((expected_inputs.linear[0] || expected_inputs.linear[1]) &&
                 (base::isUnset<double>(pose.position[0]) ||
                  base::isUnset<double>(pose.position[1]) ||
                  !base::samples::RigidBodyState::isValidValue(pose.orientation))){
             return false;
         }
-        
+
         if(expected_inputs.linear[2] && base::isUnset<double>(pose.position[2])){
             return false;
         }

--- a/test/test_pid_controller.rb
+++ b/test/test_pid_controller.rb
@@ -70,6 +70,25 @@ describe 'auv_control::PIDController' do
         assert_state_change(pid) { |s| s == :POSE_TIMEOUT }
     end
 
+    it "should not go to exception POSE_TIMEOUT" do
+
+        pid.apply_conf_file("auv_control::PIDController.yml")
+
+        pid.configure
+        sleep(pid.timeout_pose.to_i)
+        pid.start
+
+        pose_sample = generate_default_pose
+        set_point = generate_default_cmd
+
+        sleep(0.1)
+
+        pose_samples.write pose_sample
+        cmd_in.write set_point
+        cmd_out0 = assert_has_one_new_sample cmd_out, 0.1
+        assert_state_change(pid) { |s| s == :CONTROLLING }
+    end
+
     it "should go to UNSURE_POSE_SAMPLE" do
 
         pid.apply_conf_file("auv_control::PIDController.yml")


### PR DESCRIPTION
Due to the fact the timeout is set on the configureHook() and not restarted until a new pose sample is read, when syskit takes long enough to transition the task from STOPED to the RUNNING state the task goes to POSE_TIMEOUT exception as soon as the updateHook() is called. This PR fix this situation.