### PR TITLE
adding dynamic input ports from config

### DIFF
--- a/6dControl.hpp
+++ b/6dControl.hpp
@@ -35,6 +35,11 @@ namespace auv_control{
         motor_controller::PID linear[3];
         motor_controller::PID angular[3];
     };
+
+    struct InputPortConfig{
+        std::string name;
+        base::Time timeout;
+    };
 }
 
 namespace base{

--- a/auv_control.orogen
+++ b/auv_control.orogen
@@ -65,6 +65,10 @@ task_context "Base" do
         argument("name", "string").
         argument("timeout", "/base/Time").
         returns('bool')
+
+    # This property allows additional command input ports to be added on configuration.
+    property "additional_command_input", "/std/vector<auv_control/InputPortConfig>"
+
     dynamic_input_port(/cmd_\w+/, "/base/LinearAngular6DCommand")
 
     runtime_states :CONTROLLING, :CONTROLLING_UNSAFE

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -38,6 +38,15 @@ bool Base::configureHook()
     registerInput("cascade", _timeout_cascade.get(), &_cmd_cascade);
     // Assuming a max number of input ports of 6 (3 for each DOF, linear and angular)
     connected_input_ports.reserve(6);
+    std::vector<auv_control::InputPortConfig> additional_ports = _additional_command_input.get();
+    // Assuming only 4 ports are available since "in" and "cascade" are already registered
+    if (additional_ports.size() > 4){
+        additional_ports.resize(4);
+        std::cerr << "[Warning] Size of the additional input ports is bigger than 4. Taking the first four elements only!" << std::endl;
+    }
+    for(auto port : additional_ports){
+        addCommandInput(port.name, port.timeout);
+    }
     return true;
 }
 

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -39,11 +39,7 @@ bool Base::configureHook()
     // Assuming a max number of input ports of 6 (3 for each DOF, linear and angular)
     connected_input_ports.reserve(6);
     std::vector<auv_control::InputPortConfig> additional_ports = _additional_command_input.get();
-    // Assuming only 4 ports are available since "in" and "cascade" are already registered
-    if (additional_ports.size() > 4){
-        additional_ports.resize(4);
-        std::cerr << "[Warning] Size of the additional input ports is bigger than 4. Taking the first four elements only!" << std::endl;
-    }
+
     for(auto port : additional_ports){
         addCommandInput(port.name, port.timeout);
     }


### PR DESCRIPTION
Added the option of adding command input ports from a config, instead of only using an operation.